### PR TITLE
Better pagination

### DIFF
--- a/histogram_file_manager/static/histogram_file_manager/js/components/table_pagination.js
+++ b/histogram_file_manager/static/histogram_file_manager/js/components/table_pagination.js
@@ -1,17 +1,87 @@
 app.component('table-pagination', {
+    // current_page_number starts from 1
+    // page_iterator and page_number starts from 0
     template:
         /*html*/
         `
 <nav aria-label="Page navigation example" v-show="is_enabled">
-  <ul class="pagination">
-    <li class="page-item"><a class="page-link" v-on:click="clicked_previous">Previous</a></li>
-    <li class="page-item" v-for="page_number of page_iterator" :class="{active: page_number+1 == current_page_number}">
-	  <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_number+1)">
-		{{ page_number + 1 }}
-	  </a>
-	</li>
+  <ul class="pb-3 pt-3 pagination justify-content-center">
+    <li class="page-item" :class="{disabled: current_page_number == 1}">
+      <a class="page-link" v-on:click="clicked_previous">Previous</a>
+    </li>
+
+    <template v-if="total_pages <= 10">
+      <li class="page-item" v-for="page_number of page_iterator" :class="{active: page_number+1 == current_page_number}">
+      <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_number+1)">
+          {{ page_number + 1 }}
+      </a>
+      </li>
+    </template>
+    <template v-else>
+      <li class="page-item" :class="{active: current_page_number == 1}">
+        <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(1)"> 1 </a>
+      </li>
+
+      <template v-if="current_page_number <= 4">
+        <li class="page-item" :class="{active: current_page_number == 2}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(2)"> 2 </a>
+        </li>
+        <li class="page-item" :class="{active: current_page_number == 3}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(3)"> 3 </a>
+        </li>
+        <li class="page-item" v-if="current_page_number >= 3" :class="{active: current_page_number == 4}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(4)"> 4 </a>
+        </li>
+        <li class="page-item" v-if="current_page_number == 4" :class="{active: current_page_number == 5}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(5)"> 5 </a>
+        </li>
+        <li class="page-item disabled">
+          <a aria-disabled="true" class="page-link"> ... </a>
+        </li>
+      </template>
+      <template v-else-if="current_page_number >= page_length-3">
+        <li class="page-item disabled">
+            <a aria-disabled="true" class="page-link"> ... </a>
+        </li>
+        <li class="page-item" v-if="current_page_number <= page_length-3" :class="{active: current_page_number == page_length-4}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_length-4)"> {{ page_length-4 }} </a>
+        </li>
+        <li class="page-item" v-if="current_page_number <= page_length-2" :class="{active: current_page_number == page_length-3}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_length-3)"> {{ page_length-3 }} </a>
+        </li>
+        <li class="page-item" :class="{active: current_page_number == page_length-2}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_length-2)"> {{ page_length-2 }} </a>
+        </li>
+        <li class="page-item" :class="{active: current_page_number == page_length-1}">
+          <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_length-1)"> {{ page_length-1 }} </a>
+        </li>
+      </template>
+      <template v-else>
+        <li class="page-item disabled">
+          <a aria-disabled="true" class="page-link"> ... </a>
+        </li>
+        <template v-for="page_number of page_iterator">
+          <li class="page-item" v-if="(current_page_number-2 <= page_number) && (current_page_number >= page_number)" :class="{active: page_number+1 == current_page_number}">
+            <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_number+1)">
+              {{ page_number + 1 }}
+            </a>
+          </li>
+        </template>
+        <li class="page-item disabled">
+          <a aria-disabled="true" class="page-link"> ... </a>
+        </li>
+      </template>
+      
+      <li class="page-item" :class="{active: current_page_number == page_length}">
+        <a aria-disabled="true" class="page-link" v-on:click="clicked_specific_page(page_length)"> 
+          {{ page_length }}
+        </a>
+      </li>
+    </template>
 	
-    <li class="page-item"><a class="page-link" v-on:click="clicked_next">Next</a></li>
+    <li class="page-item" :class="{disabled: current_page_number == page_length}">
+      <a class="page-link" v-on:click="clicked_next">Next</a>
+    </li>
   </ul>
 </nav>
 		`,
@@ -61,7 +131,10 @@ app.component('table-pagination', {
             );
         },
         page_iterator() {
-            return Array.from(Array(parseInt(this.total_pages)).keys());
+            return Array.from(Array(Math.ceil(parseInt(this.total_pages))).keys());
         },
+        page_length() {
+            return Math.ceil(parseInt(this.total_pages));
+        }
     },
 });

--- a/histograms/tables.py
+++ b/histograms/tables.py
@@ -28,11 +28,12 @@ class LumisectionHistogram1DTable(tables.Table):
     title = tables.Column()
     entries = tables.Column()
     data = tables.Column(verbose_name="Histogram Data")
+    paginator_class = tables.LazyPaginator
 
     class Meta:
         model = LumisectionHistogram1D
         fields = ()
-        attrs = {"class": "table table-hover table-bordered"}
+        attrs = {"class": "table table-hover table-striped"}
 
 
 class LumisectionHistogram2DTable(tables.Table):
@@ -40,8 +41,9 @@ class LumisectionHistogram2DTable(tables.Table):
     lumisection = tables.Column(accessor="lumisection.ls_number")
     title = tables.Column()
     entries = tables.Column()
+    paginator_class = tables.LazyPaginator
 
     class Meta:
         model = LumisectionHistogram2D
         fields = ()
-        attrs = {"class": "table table-hover table-bordered"}
+        attrs = {"class": "table table-hover table-striped"}

--- a/histograms/templates/histograms/bootstrap.html
+++ b/histograms/templates/histograms/bootstrap.html
@@ -1,0 +1,112 @@
+{% load django_tables2 %}
+{% load i18n %}
+{% block table-wrapper %}
+<div class="table-container">
+    {% block table %}
+        <table {% render_attrs table.attrs class="table" %}>
+            {% block table.thead %}
+            {% if table.show_header %}
+                <thead {{ table.attrs.thead.as_html }}>
+                    <tr>
+                    {% for column in table.columns %}
+                        <th {{ column.attrs.th.as_html }}>
+                            {% if column.orderable %}
+                                <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            {% else %}
+                                {{ column.header }}
+                            {% endif %}
+                        </th>
+                    {% endfor %}
+                    </tr>
+                </thead>
+            {% endif %}
+            {% endblock table.thead %}
+            {% block table.tbody %}
+                <tbody {{ table.attrs.tbody.as_html }}>
+                {% for row in table.paginated_rows %}
+                    {% block table.tbody.row %}
+                    <tr {{ row.attrs.as_html }}>
+                        {% for column, cell in row.items %}
+                            <td {{ column.attrs.td.as_html }}>{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    {% endblock table.tbody.row %}
+                {% empty %}
+                    {% if table.empty_text %}
+                    {% block table.tbody.empty_text %}
+                        <tr><td colspan="{{ table.columns|length }}">{{ table.empty_text }}</td></tr>
+                    {% endblock table.tbody.empty_text %}
+                    {% endif %}
+                {% endfor %}
+                </tbody>
+            {% endblock table.tbody %}
+            {% block table.tfoot %}
+            {% if table.has_footer %}
+                <tfoot {{ table.attrs.tfoot.as_html }}>
+                    <tr>
+                    {% for column in table.columns %}
+                        <td {{ column.attrs.tf.as_html }}>{{ column.footer }}</td>
+                    {% endfor %}
+                    </tr>
+                </tfoot>
+            {% endif %}
+            {% endblock table.tfoot %}
+        </table>
+    {% endblock table %}
+
+    {% block pagination %}
+        {% if table.page and table.paginator.num_pages > 1 %}
+        <nav aria-label="Table navigation">
+            <ul class="pb-3 pagination justify-content-center">
+            {% block pagination.previous %}
+                {% if table.page.has_previous %}
+                    <li class="page-item previous">
+                        <a class="page-link" href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                            Previous
+                        </a>
+                    </li>
+                {% else %}
+                    <li class="page-item previous disabled">
+                        <a class="page-link">
+                            Previous
+                        </a>
+                    </li>
+                {% endif %}
+            {% endblock pagination.previous %}
+            {% if table.page.has_previous or table.page.has_next %}
+                {% block pagination.range %}
+                    {% for p in table.page|table_page_range:table.paginator %}
+                        <li {% if p == table.page.number %}class="page-item active"{% else %}class="page-item"{% endif %}>
+                            {% if p == '...' %}
+                                <a class="page-link" href="#">{{ p }}</a>
+                            {% else %}
+                                <a class="page-link" href="{% querystring table.prefixed_page_field=p %}">
+                                    {{ p }}
+                                </a>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                {% endblock pagination.range %}
+            {% endif %}
+
+            {% block pagination.next %}
+                {% if table.page.has_next %}
+                <li class="page-item next">
+                    <a class="page-link" href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                        Next
+                    </a>
+                </li>
+                {% else %}
+                <li class="page-item next disabled">
+                    <a class="page-link">
+                        Next
+                    </a>
+                </li>
+                {% endif %}
+            {% endblock pagination.next %}
+            </ul>
+        </nav>
+        {% endif %}
+    {% endblock pagination %}
+</div>
+{% endblock table-wrapper %}

--- a/histograms/templates/histograms/listLumisectionHistos1D.html
+++ b/histograms/templates/histograms/listLumisectionHistos1D.html
@@ -24,7 +24,7 @@ lumisection 1D histograms
     {% if lumisectionHistos1D_table %}
     <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
     <div class="overflow-auto px-3 bg-white" id="style-1">
-        {% render_table lumisectionHistos1D_table 'django_tables2/bootstrap.html'%}
+        {% render_table lumisectionHistos1D_table 'histograms/bootstrap.html' %}
     </div>
     {% else %}
         <div class="alert alert-danger" role="alert">No Table found.</div>

--- a/histograms/templates/histograms/listLumisectionHistos2D.html
+++ b/histograms/templates/histograms/listLumisectionHistos2D.html
@@ -24,7 +24,7 @@ lumisection 2D histograms
     {% if lumisectionHistos2D_table %}
     <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
     <div class="overflow-auto px-3 bg-white" id="style-1">
-        {% render_table lumisectionHistos2D_table 'django_tables2/bootstrap.html'%}
+        {% render_table lumisectionHistos2D_table 'histograms/bootstrap.html'%}
     </div>
     {% else %}
         <div class="alert alert-danger" role="alert">No Table found.</div>

--- a/histograms/views.py
+++ b/histograms/views.py
@@ -182,7 +182,7 @@ def LumisectionHistogram1DList(request):
         lumisectionHistos1D_filter.qs[:50]
     )
 
-    RequestConfig(request).configure(lumisectionHistos1D_table)
+    RequestConfig(request, paginate={"per_page": 25}).configure(lumisectionHistos1D_table)
 
     context["lumisectionHistos1D_table"] = lumisectionHistos1D_table
     context["filter"] = lumisectionHistos1D_filter
@@ -202,7 +202,7 @@ def LumisectionHistogram2DList(request):
         lumisectionHistos2D_filter.qs[:50]
     )
 
-    RequestConfig(request).configure(lumisectionHistos2D_table)
+    RequestConfig(request, paginate={"per_page": 25}).configure(lumisectionHistos2D_table)
 
     context["lumisectionHistos2D_table"] = lumisectionHistos2D_table
     context["filter"] = lumisectionHistos2D_filter


### PR DESCRIPTION
Hi,

I have improved pagination sections of Histogram File Manager table and Lumisection histogram tables so that they look better than what we have right now in production.

- In Histogram File Manager table, pagination no longer shows too many links. It will show at most five numbers if there are more than 10 pages.
- In Lumisection tables, pagination now uses Bootstrap components.
- Paginations in all tables now have the same design.

Thanks,
Vichayanun