### PR TITLE
Removed bottom navbar and adjusted page layout

### DIFF
--- a/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
+++ b/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col-9">
+    <div class="col-lg-9 col-12">
       <div class='container-fluid'>
 
       <div>
@@ -64,12 +64,14 @@
 
       </div>
     </div>
-    <div class="alert alert-info col-3">
-      <h4>Additional information - lumisections certification</h4>
-      <hr>
-      <p>
-        Per lumisection flag was obtained for all subdetectors / objects separately using the Run Registry. They were then merged into a single file which is used to fill the DB. The individual files can be found here: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/json_XXX_subdetector_good.json (the name corresponds to the numbering scheme in the RR and the name of the subdetector/object) and the final file is the following: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/LS_flags.pkl.
-      </p>
+    <div class="col-lg-3 col-12">
+      <div class="alert alert-info">
+        <h4>Additional information - lumisections certification</h4>
+        <hr>
+        <p>
+          Per lumisection flag was obtained for all subdetectors / objects separately using the Run Registry. They were then merged into a single file which is used to fill the DB. The individual files can be found here: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/json_XXX_subdetector_good.json (the name corresponds to the numbering scheme in the RR and the name of the subdetector/object) and the final file is the following: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/LS_flags.pkl.
+        </p>
+      </div>
     </div>
   </div>
 

--- a/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
+++ b/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
@@ -1,12 +1,10 @@
-{% extends 'base.html' %}
+{% extends 'base_with_sidebar.html' %}
 
 
 {% block title %} Lumisection certification with queryset {% endblock title %}
 
 
-{% block content %}
-  <div class="row">
-    <div class="col-lg-9 col-12">
+{% block maincontent %}
       <div class='container-fluid'>
 
       <div>
@@ -61,10 +59,11 @@
             {% endfor %}
           </tbody>
         </table>
-
       </div>
-    </div>
-    <div class="col-lg-3 col-12">
+
+{% endblock maincontent %}
+
+{% block sidebar %}
       <div class="alert alert-info">
         <h4>Additional information - lumisections certification</h4>
         <hr>
@@ -72,10 +71,7 @@
           Per lumisection flag was obtained for all subdetectors / objects separately using the Run Registry. They were then merged into a single file which is used to fill the DB. The individual files can be found here: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/json_XXX_subdetector_good.json (the name corresponds to the numbering scheme in the RR and the name of the subdetector/object) and the final file is the following: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/LS_flags.pkl.
         </p>
       </div>
-    </div>
-  </div>
-
-{% endblock content %}
+{% endblock sidebar %}
 
 
 {% block navbar_bottom_tabs %}

--- a/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
+++ b/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
@@ -5,61 +5,72 @@
 
 
 {% block content %}
-  <div class='container-fluid'>
+  <div class="row">
+    <div class="col-9">
+      <div class='container-fluid'>
 
-  <div>
-    {% if error_message %}
-      <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
-        <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
-        <div>
-          {{ error_message }}
-        </div>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      <div>
+        {% if error_message %}
+          <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
+            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
+            <div>
+              {{ error_message }}
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        {% endif %}
       </div>
-    {% endif %}
-  </div>
 
-  </div>
+      </div>
 
-  <div class='container-fluid'>
+      <div class='container-fluid'>
 
-    <table class="table">
-      <thead class="thead-dark">
-        <tr>
-          <th scope="col">Run number</th>
-          <th scope="col">Lumisection number</th>
-          <th scope="col">Pixel GOOD</th>
-          <th scope="col">Strip GOOD</th>
-          <th scope="col">Track GOOD</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for certification in lumisection_certifications %}
-          <tr>
-            <th scope="row">
-              <a href="{% url 'data_taking_objects:run-view' run_number=certification.lumisection.run.run_number %}">
-                {{ certification.lumisection.run.run_number }}
-              </a>
-            </th>
-            <th>
-              <a href="{% url 'data_taking_objects:lumisection-view' run_number=certification.lumisection.run.run_number lumi_number=certification.lumisection.ls_number %}">
-                {{ certification.lumisection.ls_number }}
-              </a>
-            </th>
-            <td>
-              {{ certification.rr_is_pixel_good }}
-            </td>
-            <td>
-              {{ certification.rr_is_strip_good }}
-            </td>
-            <td>
-              {{ certification.rr_is_tracking_good }}
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+        <table class="table">
+          <thead class="thead-dark">
+            <tr>
+              <th scope="col">Run number</th>
+              <th scope="col">Lumisection number</th>
+              <th scope="col">Pixel GOOD</th>
+              <th scope="col">Strip GOOD</th>
+              <th scope="col">Track GOOD</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for certification in lumisection_certifications %}
+              <tr>
+                <th scope="row">
+                  <a href="{% url 'data_taking_objects:run-view' run_number=certification.lumisection.run.run_number %}">
+                    {{ certification.lumisection.run.run_number }}
+                  </a>
+                </th>
+                <th>
+                  <a href="{% url 'data_taking_objects:lumisection-view' run_number=certification.lumisection.run.run_number lumi_number=certification.lumisection.ls_number %}">
+                    {{ certification.lumisection.ls_number }}
+                  </a>
+                </th>
+                <td>
+                  {{ certification.rr_is_pixel_good }}
+                </td>
+                <td>
+                  {{ certification.rr_is_strip_good }}
+                </td>
+                <td>
+                  {{ certification.rr_is_tracking_good }}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
 
+      </div>
+    </div>
+    <div class="alert alert-info col-3">
+      <h4>Additional information - lumisections certification</h4>
+      <hr>
+      <p>
+        Per lumisection flag was obtained for all subdetectors / objects separately using the Run Registry. They were then merged into a single file which is used to fill the DB. The individual files can be found here: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/json_XXX_subdetector_good.json (the name corresponds to the numbering scheme in the RR and the name of the subdetector/object) and the final file is the following: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/LS_flags.pkl.
+      </p>
+    </div>
   </div>
 
 {% endblock content %}

--- a/data_taking_objects/templates/data_taking_objects/run.html
+++ b/data_taking_objects/templates/data_taking_objects/run.html
@@ -1,13 +1,10 @@
-{% extends 'base.html' %}
+{% extends 'base_with_sidebar.html' %}
 
 
 {% block title %} Run {{ run.run_number }} {% endblock title %}
 
 
-{% block content %}
-
-  <div class="row">
-    <div class="col-lg-9 col-12">
+{% block maincontent %}
     <div>
       {% if error_message %}
         <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
@@ -42,19 +39,18 @@
       </table>
 
     </div>
-    </div>
-    <div class="col-lg-3 col-12">
-      <h4>More from OMS</h4>
-      <hr>
-      <ol>
-        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{run.run_number}}">Run {{run.run_number}}</a></li>
-        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{run.run_number}}">L1 rates from run {{run.run_number}}</a></li>
-        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{run.run_number}}">HLT rates from run {{run.run_number}}</a></li>
-      </ol>
-    </div>
-  </div>
 
-{% endblock content %}
+{% endblock maincontent %}
+
+{% block sidebar %}
+  <h4>More from OMS</h4>
+  <hr>
+  <ol>
+    <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{run.run_number}}">Run {{run.run_number}}</a></li>
+    <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{run.run_number}}">L1 rates from run {{run.run_number}}</a></li>
+    <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{run.run_number}}">HLT rates from run {{run.run_number}}</a></li>
+  </ol>
+{% endblock sidebar %}
 
 
 {% block navbar_bottom_tabs %}

--- a/data_taking_objects/templates/data_taking_objects/run.html
+++ b/data_taking_objects/templates/data_taking_objects/run.html
@@ -7,7 +7,7 @@
 {% block content %}
 
   <div class="row">
-    <div class="col-9">
+    <div class="col-lg-9 col-12">
     <div>
       {% if error_message %}
         <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
@@ -43,7 +43,7 @@
 
     </div>
     </div>
-    <div class="col-3">
+    <div class="col-lg-3 col-12">
       <h4>More from OMS</h4>
       <hr>
       <ol>

--- a/data_taking_objects/templates/data_taking_objects/run.html
+++ b/data_taking_objects/templates/data_taking_objects/run.html
@@ -6,39 +6,52 @@
 
 {% block content %}
 
-  <div>
-    {% if error_message %}
-      <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
-        <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
-        <div>
-          {{ error_message }}
+  <div class="row">
+    <div class="col-9">
+    <div>
+      {% if error_message %}
+        <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
+          <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
+          <div>
+            {{ error_message }}
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endif %}
-  </div>
+      {% endif %}
+    </div>
 
-  <div class='container-fluid'>
+    <div class='container-fluid'>
 
-    <table class="table">
-      <thead class="thead-dark">
-        <tr>
-          <th scope="col">Run number</th>
-          <th scope="col">Number of lumisections</th>
-          <th scope="col">Integrated luminosity</th>
-          <th scope="col">Initial ZeroBias rate</th>
-        </tr>
-      </thead>
-      <tbody>
+      <table class="table">
+        <thead class="thead-dark">
           <tr>
-            <th scope="row">{{ run.run_number }}</th>
-            <td>XXX</td>
-            <td>XXX</td>
-            <td>XXX</td>
+            <th scope="col">Run number</th>
+            <th scope="col">Number of lumisections</th>
+            <th scope="col">Integrated luminosity</th>
+            <th scope="col">Initial ZeroBias rate</th>
           </tr>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+            <tr>
+              <th scope="row">{{ run.run_number }}</th>
+              <td>XXX</td>
+              <td>XXX</td>
+              <td>XXX</td>
+            </tr>
+        </tbody>
+      </table>
 
+    </div>
+    </div>
+    <div class="col-3">
+      <h4>More from OMS</h4>
+      <hr>
+      <ol>
+        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{run.run_number}}">Run {{run.run_number}}</a></li>
+        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{run.run_number}}">L1 rates from run {{run.run_number}}</a></li>
+        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{run.run_number}}">HLT rates from run {{run.run_number}}</a></li>
+      </ol>
+    </div>
   </div>
 
 {% endblock content %}

--- a/data_taking_objects/templates/data_taking_objects/runs.html
+++ b/data_taking_objects/templates/data_taking_objects/runs.html
@@ -6,55 +6,75 @@
 
 {% block content %}
 
-  <div>
-    {% if error_message %}
-      <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
-        <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
-        <div>
-          {{ error_message }}
-        </div>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <div class="row">
+    <div class="col-9">
+      <div>
+        {% if error_message %}
+          <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
+            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
+            <div>
+              {{ error_message }}
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        {% endif %}
       </div>
-    {% endif %}
-  </div>
 
-  <div class='container-fluid'>
+      <div class='container-fluid'>
 
-    <table class="table">
-      <thead class="thead-dark">
-        <tr>
-          <th scope="col">Run number</th>
-          <th scope="col">OMS info</th>
-          <th scope="col">RR OMS info</th>
-          <th scope="col">Histograms</th>
-          <th scope="col">RR certification info</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for run in runs %}
-          <tr>
-            <th scope="row"> 
-              <a href="{% url 'data_taking_objects:run-view' run_number=run.run_number %}">
-                {{ run.run_number }}
-              </a>
-            </th>
-            <td>
-              <span class="badge bg-warning">Not available</span>
-            </td>
-            <td>
-              <span class="badge bg-success">Available</span>
-            </td>
-            <td>
-              <span class="badge bg-success"> {{ run.histograms.count }} histograms available</span>
-            </td>
-            <td>
-              <span class="badge bg-success">Available</span>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+        <table class="table">
+          <thead class="thead-dark">
+            <tr>
+              <th scope="col">Run number</th>
+              <th scope="col">OMS info</th>
+              <th scope="col">RR OMS info</th>
+              <th scope="col">Histograms</th>
+              <th scope="col">RR certification info</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for run in runs %}
+              <tr>
+                <th scope="row"> 
+                  <a href="{% url 'data_taking_objects:run-view' run_number=run.run_number %}">
+                    {{ run.run_number }}
+                  </a>
+                </th>
+                <td>
+                  <span class="badge bg-warning">Not available</span>
+                </td>
+                <td>
+                  <span class="badge bg-success">Available</span>
+                </td>
+                <td>
+                  <span class="badge bg-success"> {{ run.histograms.count }} histograms available</span>
+                </td>
+                <td>
+                  <span class="badge bg-success">Available</span>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
 
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="alert alert-info">
+        <h4>Additional information - runs</h4>
+        <hr>
+        <p>
+          The histograms for 2018 were extracted from the ML4DQM .csv files using <a href="https://github.com/XavierAtCERN/MLplayground/blob/master/histograms/management/commands/extract_run_histograms.py">the following script</a>.
+        </p>
+      </div>
+      <h4>Data sources</h4>
+      <hr>
+      <ul>
+        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/index/index">OMS</a></li>
+        <li><a class="nav-link" href="https://cmsrunregistry.web.cern.ch/offline/datasets/global">Run Registry</a></li>
+        <li><a class="nav-link" href="#">Histograms</a></li>
+      </ul>
+    </div>
   </div>
 
 {% endblock content %}

--- a/data_taking_objects/templates/data_taking_objects/runs.html
+++ b/data_taking_objects/templates/data_taking_objects/runs.html
@@ -7,7 +7,7 @@
 {% block content %}
 
   <div class="row">
-    <div class="col-9">
+    <div class="col-lg-9 col-12">
       <div>
         {% if error_message %}
           <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
@@ -59,7 +59,7 @@
 
       </div>
     </div>
-    <div class="col-3">
+    <div class="col-lg-3 col-12">
       <div class="alert alert-info">
         <h4>Additional information - runs</h4>
         <hr>

--- a/data_taking_objects/templates/data_taking_objects/runs.html
+++ b/data_taking_objects/templates/data_taking_objects/runs.html
@@ -1,13 +1,10 @@
-{% extends 'base.html' %}
+{% extends 'base_with_sidebar.html' %}
 
 
 {% block title %} Runs {% endblock title %}
 
 
-{% block content %}
-
-  <div class="row">
-    <div class="col-lg-9 col-12">
+{% block maincontent %}
       <div>
         {% if error_message %}
           <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
@@ -58,8 +55,9 @@
         </table>
 
       </div>
-    </div>
-    <div class="col-lg-3 col-12">
+{% endblock maincontent %}
+
+{% block sidebar %}
       <div class="alert alert-info">
         <h4>Additional information - runs</h4>
         <hr>
@@ -74,11 +72,7 @@
         <li><a class="nav-link" href="https://cmsrunregistry.web.cern.ch/offline/datasets/global">Run Registry</a></li>
         <li><a class="nav-link" href="#">Histograms</a></li>
       </ul>
-    </div>
-  </div>
-
-{% endblock content %}
-
+{% endblock sidebar%}
 
 {% block navbar_bottom_tabs %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,6 +57,7 @@
       </div>
 
 	  <!-- Navbar bottom -->
+    <!--
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-bottom px-4">
           <a class="navbar-brand">Data Sources</a>
 
@@ -90,6 +91,7 @@
           </div>
         </div>
       </div>
+    -->
 
     </body>
 

--- a/templates/base_with_sidebar.html
+++ b/templates/base_with_sidebar.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-lg-9 col-12">
+      {% block maincontent %}
+        Default Bootstrap Container.
+      {% endblock %}
+    </div>
+    <div class="col-lg-3 col-12">
+      {% block sidebar %}
+      {% endblock %}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
Hi,

I noticed that the bottom navbar only contains information in runs, run, and lumisection certification pages, and does not show any information in other pages. Since it does not show information in all pages, I decided to remove the bottom navbar and put additional information by adjusting the page layout directly.

I understand that the idea of putting text in modal templates is for maintainers to easily add and adjust information, so I will have to come up with a better solution that can show the text when needed and hide the extra column when not needed.

Thanks,
Vichayanun