### PR TITLE
Removing lumisection histogram limit

### DIFF
--- a/histograms/templates/histograms/filter_lumisections_1d.html
+++ b/histograms/templates/histograms/filter_lumisections_1d.html
@@ -161,7 +161,7 @@
                             <div class="col-sm-6" style="margin-top: 10px">
                                 <a href="#" data-bs-toggle="tooltip" title="use CTRL + Click to select and deselect multiple titles" style="color:black;
         text-decoration: none;">Help</a>
-                                {% render_field filter.form.title|add_class:"form-control" %}
+                                {% render_field filter.form.title|add_class:"form-select" %}
                             </div>
                         </div>
                         

--- a/histograms/templates/histograms/filter_lumisections_1d.html
+++ b/histograms/templates/histograms/filter_lumisections_1d.html
@@ -161,7 +161,7 @@
                             <div class="col-sm-6" style="margin-top: 10px">
                                 <a href="#" data-bs-toggle="tooltip" title="use CTRL + Click to select and deselect multiple titles" style="color:black;
         text-decoration: none;">Help</a>
-                                {% render_field filter.form.title|add_class:"form-select" %}
+                                {% render_field filter.form.title|add_class:"form-control" %}
                             </div>
                         </div>
                         

--- a/histograms/views.py
+++ b/histograms/views.py
@@ -179,7 +179,7 @@ def LumisectionHistogram1DList(request):
         request.GET, queryset=lumisectionHistos1D_list
     )
     lumisectionHistos1D_table = LumisectionHistogram1DTable(
-        lumisectionHistos1D_filter.qs[:50]
+        lumisectionHistos1D_filter.qs
     )
 
     RequestConfig(request, paginate={"per_page": 25}).configure(lumisectionHistos1D_table)
@@ -199,7 +199,7 @@ def LumisectionHistogram2DList(request):
         request.GET, queryset=lumisectionHistos2D_list
     )
     lumisectionHistos2D_table = LumisectionHistogram2DTable(
-        lumisectionHistos2D_filter.qs[:50]
+        lumisectionHistos2D_filter.qs
     )
 
     RequestConfig(request, paginate={"per_page": 25}).configure(lumisectionHistos2D_table)


### PR DESCRIPTION
Hi,

Yesterday I have discovered a limit of 50 histograms in 1D and 2D LS histogram listing pages. I understand that this is for demonstration purpose, but I think it would be better if we can have the whole list of lumisections instead of limiting to the first 50 histograms. If we can have the whole list of ~400k lumisections (with pagination of course) it would better demonstrate that our web app can store a large amount of histograms in its database.

Thanks,
Vichayanun