### PR TITLE
Restructuring frontend

### DIFF
--- a/common/static/css/style.css
+++ b/common/static/css/style.css
@@ -3,7 +3,18 @@
   background-color: rgb(150, 245, 245);
 }
 
+.navbar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 60px;
+  z-index: 999;
+  backdrop-filter: blur(10px);
+  background-color: rgba(22, 22, 23, .8);
+}
+
 .container-main-page{
   margin: 20px;
   padding: 20px;
+  margin-top: 60px;
 }

--- a/common/static/css/style.css
+++ b/common/static/css/style.css
@@ -4,10 +4,7 @@
 }
 
 .navbar {
-  position: fixed;
-  top: 0;
   width: 100%;
-  height: 60px;
   z-index: 999;
   backdrop-filter: blur(10px);
   background-color: rgba(22, 22, 23, .8);

--- a/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
+++ b/data_taking_certification/templates/data_taking_certification/lumisection_certification.html
@@ -68,7 +68,7 @@
         <h4>Additional information - lumisections certification</h4>
         <hr>
         <p>
-          Per lumisection flag was obtained for all subdetectors / objects separately using the Run Registry. They were then merged into a single file which is used to fill the DB. The individual files can be found here: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/json_XXX_subdetector_good.json (the name corresponds to the numbering scheme in the RR and the name of the subdetector/object) and the final file is the following: /afs/cern.ch/user/x/xcoubez/public/ML4DQM/LS_flags.pkl.
+          Per lumisection flag was obtained for all subdetectors / objects separately using the Run Registry. They were then merged into a single file which is used to fill the DB. The individual files can be found here: <code>/afs/cern.ch/user/x/xcoubez/public/ML4DQM/json_XXX_subdetector_good.json</code> (the name corresponds to the numbering scheme in the RR and the name of the subdetector/object) and the final file is the following: <code>/afs/cern.ch/user/x/xcoubez/public/ML4DQM/LS_flags.pkl</code>.
         </p>
       </div>
 {% endblock sidebar %}

--- a/data_taking_objects/templates/data_taking_objects/lumisection.html
+++ b/data_taking_objects/templates/data_taking_objects/lumisection.html
@@ -3,6 +3,9 @@
 {% block title %} Run {{ runnr }}, lumisection {{ lumi_number }} {% endblock title %}
 
 {% block maincontent %}
+<div class='container-fluid'>
+  <i class="bi bi-chevron-left"></i> <a href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">All runs</a> / <a href="{% url 'visualize_histogram:redirect_run' runnr=runnr %}">Run {{ runnr }}</a>
+</div>
 
   <div>
     {% if error_message %}
@@ -19,7 +22,7 @@
   <div class='container-fluid'>
 
 
-    <h2><a href="{% url 'visualize_histogram:redirect_run' runnr=runnr %}">Run {{ runnr }}</a>, lumisection {{ lumi_number }}</h2>
+    <h2>Run {{ runnr }}, lumisection {{ lumi_number }}</h2>
     {% if n_hist1d != 0 %}
     <hr>
     <h3>1D histograms</h3>

--- a/data_taking_objects/templates/data_taking_objects/lumisection.html
+++ b/data_taking_objects/templates/data_taking_objects/lumisection.html
@@ -1,8 +1,8 @@
-{% extends 'base.html' %}
+{% extends 'base_with_sidebar.html' %}
 
-{% block title %} Run {{lumisection.run.run_number}} - Lumisection {{lumisection.ls_number}} {% endblock title %}
+{% block title %} Run {{ runnr }}, lumisection {{ lumi_number }} {% endblock title %}
 
-{% block content %}
+{% block maincontent %}
 
   <div>
     {% if error_message %}
@@ -18,25 +18,101 @@
 
   <div class='container-fluid'>
 
-    <table class="table">
-      <thead class="thead-dark">
-        <tr>
-          <th scope="col">Run number</th>
-          <th scope="col">Lumisection number</th>
-          <th scope="col">Integrated luminosity</th>
-          <th scope="col">Initial ZeroBias rate</th>
-        </tr>
-      </thead>
-      <tbody>
-          <tr>
-            <th scope="row"> {{ lumisection.run.run_number }} </th>
-            <th> {{ lumisection.ls_number}} </th>
-            <td>XXX</td>
-            <td>XXX</td>
-          </tr>
-      </tbody>
-    </table>
+
+    <h2><a href="{% url 'visualize_histogram:redirect_run' runnr=runnr %}">Run {{ runnr }}</a>, lumisection {{ lumi_number }}</h2>
+    {% if n_hist1d != 0 %}
+    <hr>
+    <h3>1D histograms</h3>
+    <div>
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+        {% for hist in hist1d %}
+        <div class="col">
+          <a class="card" href="{% url 'visualize_histogram:visualize_histogram' runnr=runnr lumisection=lumi_number title=hist.title %}">
+            <div class="card-img-top" id="histogram-id-{{hist.id}}" style="height: 200px;">
+              <script>
+                  var trace = {
+                      y: {{ hist.data }},
+                      type: 'bar',
+                      marker: {color: '#0033A0'}
+                  };
+                  var data = [trace];
+
+                  Plotly.newPlot("histogram-id-{{hist.id}}", data, 
+                  {
+                      margin: {t: 10, b: 10, l: 10, r: 10},
+                      yaxis: {"visible": false}, 
+                      xaxis: {"visible": false}, 
+                      bargap: 0, 
+                      paper_bgcolor: 'rgba(0,0,0,0)',
+                      plot_bgcolor: 'rgba(0,0,0,0)'
+                }, {staticPlot: true});
+              </script>
+            </div>
+            <div class="card-body">
+              {{ hist.title }}
+            </div>
+          </a>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if n_hist2d != 0 %}
+    <hr>
+    <h3>2D histograms</h3>
+    <div>
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+        {% for hist in hist2d %}
+        <div class="col">
+          <a class="card" href="{% url 'visualize_histogram:visualize_histogram' runnr=runnr lumisection=lumi_number title=hist.title %}">
+            <div class="card-img-top" id="histogram-id-{{hist.id}}" style="height: 200px;">
+              <script>
+                  var data = [
+                      {
+                          z: {{ hist.data }},
+                          type: 'heatmap',
+                          colorscale: 'Viridis'
+                      }
+                  ];
+  
+                  Plotly.newPlot("histogram-id-{{hist.id}}", data, 
+                  {
+                    margin: {t: 10, b: 10, l: 10, r: 10}, 
+                    yaxis: {"visible": false}, 
+                    xaxis: {"visible": false}, 
+                    bargap: 0, 
+                    paper_bgcolor: 'rgba(0,0,0,0)',
+                    plot_bgcolor: 'rgba(0,0,0,0)'
+                  }, {staticPlot: true});
+              </script>
+            </div>
+            <div class="card-body">
+              {{ hist.title }}
+            </div>
+          </a>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
 
   </div>
 
-{% endblock content %}
+{% endblock maincontent %}
+
+{% block sidebar %}
+  <table class="table">
+    <tbody>
+      <tr>
+        <th scope="col">Integrated luminosity</th>
+        <td>XXX</td>
+      </tr>
+      <tr>
+        <th scope="col">Initial ZeroBias rate</th>
+        <td>XXX</td>
+      </tr>
+    </tbody>
+  </table>
+{% endblock sidebar %}

--- a/data_taking_objects/templates/data_taking_objects/lumisections.html
+++ b/data_taking_objects/templates/data_taking_objects/lumisections.html
@@ -46,16 +46,16 @@
               </a>
             </th>
             <td>
-              <span class="badge bg-warning">Not available</span>
+              <i class="bi bi-x-lg"></i>
             </td>
             <td>
-              <span class="badge bg-success"> {{ lumisection.histograms_lumisectionhistogram1d_histograms.count }} 1D histograms</span>
+              {{ lumisection.histograms_lumisectionhistogram1d_histograms.count }}
             </td>
             <td>
-              <span class="badge bg-success"> {{ lumisection.histograms_lumisectionhistogram2d_histograms.count }} 2D histograms</span>
+              {{ lumisection.histograms_lumisectionhistogram2d_histograms.count }}
             </td>
             <td>
-              <span class="badge bg-success">Available</span>
+              <i class="bi bi-check-lg"></i>
             </td>
           </tr>
         {% endfor %}

--- a/data_taking_objects/templates/data_taking_objects/run.html
+++ b/data_taking_objects/templates/data_taking_objects/run.html
@@ -7,7 +7,7 @@
 {% block maincontent %}
 
     <div class='container-fluid'>
-      <a href="{% url 'visualize_histogram:visualize_histogram_dummy' %}"><i class="bi bi-arrow-left"></i> Back to all runs</a>
+      <i class="bi bi-chevron-left"></i> <a href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">All runs</a>
       <h2>Run {{ runnr }} has {{ num_lumisections }} {% if num_lumisections != 1 %}lumisections{% else %}lumisection{% endif %}</h2>
 
       <div>

--- a/data_taking_objects/templates/data_taking_objects/run.html
+++ b/data_taking_objects/templates/data_taking_objects/run.html
@@ -5,38 +5,59 @@
 
 
 {% block maincontent %}
-    <div>
-      {% if error_message %}
-        <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
-          <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
-          <div>
-            {{ error_message }}
-          </div>
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
-      {% endif %}
-    </div>
 
     <div class='container-fluid'>
+      <a href="{% url 'visualize_histogram:visualize_histogram_dummy' %}"><i class="bi bi-arrow-left"></i> Back to all runs</a>
+      <h2>Run {{ runnr }} has {{ num_lumisections }} {% if num_lumisections != 1 %}lumisections{% else %}lumisection{% endif %}</h2>
 
+      <div>
+        {% if error_message %}
+          <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
+            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
+            <div>
+              {{ error_message }}
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        {% endif %}
+      </div>
+
+      {% if lumisections %}
       <table class="table">
         <thead class="thead-dark">
           <tr>
-            <th scope="col">Run number</th>
-            <th scope="col">Number of lumisections</th>
+            <th scope="col">Lumisection</th>
+            <th scole="col">1D histograms</th>
+            <th scole="col">2D histograms</th>
             <th scope="col">Integrated luminosity</th>
             <th scope="col">Initial ZeroBias rate</th>
           </tr>
         </thead>
         <tbody>
-            <tr>
-              <th scope="row">{{ run.run_number }}</th>
-              <td>XXX</td>
-              <td>XXX</td>
-              <td>XXX</td>
-            </tr>
+            {% for lumisection in lumisections %}
+              <tr>
+                <th>
+                  <a href="{% url 'visualize_histogram:redirect_lumisection' runnr=run.run_number lumisection=lumisection.ls_number%}">
+                    {{ lumisection.ls_number }}
+                  </a>
+                </th>
+                <td>
+                  {{ lumisection.histograms_lumisectionhistogram1d_histograms.count }}
+                </td>
+                <td>
+                  {{ lumisection.histograms_lumisectionhistogram2d_histograms.count }}
+                </td>
+                <td>
+                  ?
+                </td>
+                <td>
+                  ?
+                </td>
+              </tr>
+            {% endfor %}
         </tbody>
       </table>
+      {% endif %}
 
     </div>
 
@@ -45,33 +66,12 @@
 {% block sidebar %}
   <h4>More from OMS</h4>
   <hr>
-  <ol>
-    <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{run.run_number}}">Run {{run.run_number}}</a></li>
-    <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{run.run_number}}">L1 rates from run {{run.run_number}}</a></li>
-    <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{run.run_number}}">HLT rates from run {{run.run_number}}</a></li>
-  </ol>
+  <ul>
+    <li><a href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{run.run_number}}">Run {{run.run_number}}</a></li>
+    <li><a href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{run.run_number}}">L1 rates from run {{run.run_number}}</a></li>
+    <li><a href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{run.run_number}}">HLT rates from run {{run.run_number}}</a></li>
+  </ul>
 {% endblock sidebar %}
-
-
-{% block navbar_bottom_tabs %}
-
-  <li class="nav-item">
-    <a class="nav-link">OMS</a>
-  </li>
-
-  <li class="nav-item">
-    <a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{run.run_number}}">Runs</a>
-  </li>
-
-  <li class="nav-item">
-    <a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{run.run_number}}">L1 rates</a>
-  </li>
-
-  <li class="nav-item">
-    <a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{run.run_number}}">HLT rates</a>
-  </li>
-
-{% endblock navbar_bottom_tabs %}
 
 {% block modal_tab %} Additional information {% endblock modal_tab %}
 

--- a/data_taking_objects/templates/data_taking_objects/runs.html
+++ b/data_taking_objects/templates/data_taking_objects/runs.html
@@ -5,6 +5,31 @@
 
 
 {% block maincontent %}
+<h2>Jump quickly</h2>
+<form action="" method="GET" class="row">
+    <div class="col-6 col-lg-2">
+        {{ form.runnr.errors }}
+        <label for="{{ form.runnr.id_for_label }}">Run</label>
+        {{ form.runnr }}
+    </div>
+    <div class="col-6 col-lg-2">
+        {{ form.lumisection.errors }}
+        <label for="{{ form.lumisection.id_for_label }}">Lumisection</label>
+        {{ form.lumisection }}
+    </div>
+    <div class="col-12 col-lg-7">
+        {{ form.title.errors }}
+        <label for="{{ form.title.id_for_label }}">Title</label>
+        {{ form.title }}
+    </div>
+    <div class="col-12 col-lg-1">
+        <br>
+        <div class="d-grid">
+            <button class="btn btn-primary" type="submit">Go</button>
+        </div>
+    </div>
+</form>
+
       <div>
         {% if error_message %}
           <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">
@@ -25,7 +50,7 @@
               <th scope="col">Run number</th>
               <th scope="col">OMS info</th>
               <th scope="col">RR OMS info</th>
-              <th scope="col">Histograms</th>
+              <th scope="col">Run level histograms</th>
               <th scope="col">RR certification info</th>
             </tr>
           </thead>
@@ -33,21 +58,21 @@
             {% for run in runs %}
               <tr>
                 <th scope="row"> 
-                  <a href="{% url 'data_taking_objects:run-view' run_number=run.run_number %}">
+                  <a href="{% url 'visualize_histogram:redirect_run' runnr=run.run_number %}">
                     {{ run.run_number }}
                   </a>
                 </th>
                 <td>
-                  <span class="badge bg-warning">Not available</span>
+                  <i class="bi bi-x-lg"></i>
                 </td>
                 <td>
-                  <span class="badge bg-success">Available</span>
+                  <i class="bi bi-check-lg"></i>
                 </td>
                 <td>
-                  <span class="badge bg-success"> {{ run.histograms.count }} histograms available</span>
+                  {{ run.histograms.count }}
                 </td>
                 <td>
-                  <span class="badge bg-success">Available</span>
+                  <i class="bi bi-check-lg"></i>
                 </td>
               </tr>
             {% endfor %}
@@ -68,9 +93,9 @@
       <h4>Data sources</h4>
       <hr>
       <ul>
-        <li><a class="nav-link" href="https://cmsoms.cern.ch/cms/index/index">OMS</a></li>
-        <li><a class="nav-link" href="https://cmsrunregistry.web.cern.ch/offline/datasets/global">Run Registry</a></li>
-        <li><a class="nav-link" href="#">Histograms</a></li>
+        <li><a href="https://cmsoms.cern.ch/cms/index/index">OMS</a></li>
+        <li><a href="https://cmsrunregistry.web.cern.ch/offline/datasets/global">Run Registry</a></li>
+        <li><a href="#">Histograms</a></li>
       </ul>
 {% endblock sidebar%}
 

--- a/data_taking_objects/templates/data_taking_objects/runs.html
+++ b/data_taking_objects/templates/data_taking_objects/runs.html
@@ -5,7 +5,7 @@
 
 
 {% block maincontent %}
-<h2>Jump quickly</h2>
+<h2>Jump quickly...</h2>
 <form action="" method="GET" class="row">
     <div class="col-6 col-lg-2">
         {{ form.runnr.errors }}
@@ -30,6 +30,7 @@
     </div>
 </form>
 
+<h2 style="margin-top:10px">...or browse through runs</h2>
       <div>
         {% if error_message %}
           <div class="alert alert-warning d-flex align-items-center alert-dismissible fade show" role="alert">

--- a/histogram_file_manager/api/filters.py
+++ b/histogram_file_manager/api/filters.py
@@ -27,7 +27,7 @@ class HistogramDataFileFilter(filters.FilterSet):
     processing_complete = filters.BooleanFilter(
         label="Processing complete",
         method="filter_processing_complete",
-        widget=NullBooleanSelect(attrs={"class": "form-control"}),
+        widget=NullBooleanSelect(attrs={"class": "form-select"}),
     )
 
     filepath__contains = filters.CharFilter(
@@ -44,13 +44,13 @@ class HistogramDataFileFilter(filters.FilterSet):
     data_dimensionality = filters.ChoiceFilter(
         choices=HistogramDataFileContents.HISTOGRAM_DIMENSIONS_CHOICES,
         field_name="contents__data_dimensionality",
-        widget=Select(attrs={"class": "form-control"}),
+        widget=Select(attrs={"class": "form-select"}),
     )
 
     granularity = filters.ChoiceFilter(
         choices=HistogramDataFileContents.DATAFILE_GRANULARITY_CHOICES,
         field_name="contents__granularity",
-        widget=Select(attrs={"class": "form-control"}),
+        widget=Select(attrs={"class": "form-select"}),
     )
 
     def filter_processing_complete(self, queryset, name, value):

--- a/histogram_file_manager/forms.py
+++ b/histogram_file_manager/forms.py
@@ -8,9 +8,14 @@ class HistogramDataFileStartParsingForm(forms.Form):
     """
 
     granularity = forms.ChoiceField(
-        choices=HistogramDataFileContents.DATAFILE_GRANULARITY_CHOICES
+        choices=HistogramDataFileContents.DATAFILE_GRANULARITY_CHOICES,
+        widget=forms.Select(attrs={'class': 'form-select'})
     )
     data_dimensionality = forms.ChoiceField(
-        choices=HistogramDataFileContents.HISTOGRAM_DIMENSIONS_CHOICES
+        choices=HistogramDataFileContents.HISTOGRAM_DIMENSIONS_CHOICES,
+        widget=forms.Select(attrs={'class': 'form-select'})
     )
-    file_format = forms.ChoiceField(choices=HistogramDataFile.DATAFILE_FORMAT_CHOICES)
+    file_format = forms.ChoiceField(
+        choices=HistogramDataFile.DATAFILE_FORMAT_CHOICES,
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )

--- a/histogram_file_manager/static/histogram_file_manager/js/components/file_actions.js
+++ b/histogram_file_manager/static/histogram_file_manager/js/components/file_actions.js
@@ -8,34 +8,32 @@ app.component('file-actions', {
   <div class="modal-dialog" role="document">
 	<div class="modal-content">
 	  <div class="modal-header">
-        <h5 class="modal-title">File actions (File {{ file_id }})</h5>
+        <h5 class="modal-title">File {{ file_id }} actions</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" v-on:click="clicked_close">        </button>
 	  </div>
 	  <div class="modal-body">
     <success :success="success" @dismissed-success="dismiss_success"></success>
 		<errors :errors="errors" @dismissed-error="dismiss_error"></errors>
-		<div class="container-fluid">
-		  <table class="table">
-			<thead>
-			</thead>
-			<tbody>
-			  <tr>
-				<th scope="row">Filepath</th>
-				<td><code>{{ file_information['filepath'] }}</code></td>
-			  </tr>
-			  <tr v-if="file_information['data_dimensionality'] !== 0">
-				<th scope="row">Dimensionality</th>
-				<td>{{ file_information['data_dimensionality'] }}</td>
-			  </tr>
-			  <tr v-if="file_information['granularity'] !== 'unk'">
-				<th scope="row">Granularity</th>
-				<td>{{ file_information['granularity'] }}</td>
-			  </tr>			  
-			</tbody>
-		  </table>
-		</div>
+    <table class="table">
+    <thead>
+    </thead>
+    <tbody>
+      <tr>
+      <th scope="row">File path</th>
+      <td><code>{{ file_information['filepath'] }}</code></td>
+      </tr>
+      <tr v-if="file_information['data_dimensionality'] !== 0">
+      <th scope="row">Dimensionality</th>
+      <td>{{ file_information['data_dimensionality'] }}</td>
+      </tr>
+      <tr v-if="file_information['granularity'] !== 'unk'">
+      <th scope="row">Granularity</th>
+      <td>{{ file_information['granularity'] }}</td>
+      </tr>			  
+    </tbody>
+    </table>
 		<!-- {{ Object.keys(file_information) }} -->
-		<form @submit.prevent="send_parse_file_command">
+		<form @submit.prevent="send_parse_file_command" style="padding: 8px;">
 		  <div class="form-group" v-for="(choices, field_name) in field_choices">
 			<label :for="field_name">{{ field_name }}</label>
 			<select class="form-select" :id="field_name" v-model="$data[field_name]">
@@ -44,17 +42,18 @@ app.component('file-actions', {
 			  </option>
 			</select>
 		  </div>
-		  <input
-			type="submit"
-			class="btn btn-primary mt-3"
-			:class="{disabled: file_information.percentage_processed === 100.0 }"
-			value="Parse">
+      <div class="d-grid">
+        <input type="submit" class="btn btn-primary mt-3" :class="{disabled: file_information.percentage_processed === 100.0 }"
+        value="Parse">
+      </div>
 		</form>
 		<!-- Delete from Database -->
-		<button @click="delete_file_command(file_id)"
-				class="btn btn-danger mt-3">
-		  <i class="bi bi-trash-fill"></i> Delete from DB
-		</button>		
+    <div class="d-grid" style="padding: 8px">
+      <button @click="delete_file_command(file_id)"
+          class="btn btn-danger">
+        <i class="bi bi-trash-fill"></i> Delete from DB
+      </button>
+    </div>
       </div>
       <div class="modal-footer">
       </div>

--- a/histogram_file_manager/static/histogram_file_manager/js/components/file_actions.js
+++ b/histogram_file_manager/static/histogram_file_manager/js/components/file_actions.js
@@ -53,7 +53,7 @@ app.component('file-actions', {
 		<!-- Delete from Database -->
 		<button @click="delete_file_command(file_id)"
 				class="btn btn-danger mt-3">
-		  <i class="bi bi-trash-fill"></i>Delete from DB
+		  <i class="bi bi-trash-fill"></i> Delete from DB
 		</button>		
       </div>
       <div class="modal-footer">

--- a/histogram_file_manager/static/histogram_file_manager/js/components/file_table.js
+++ b/histogram_file_manager/static/histogram_file_manager/js/components/file_table.js
@@ -8,24 +8,24 @@ app.component('file-table', {
 	<table class="table table-sm table-hover table-striped">
 	  <thead class="thead-dark">
 		<tr>
-		  <th scope="col"
-			  v-for="header in headers"
-			  :key="header">
-			{{ header }}
-		  </th>
-		  <th>Actions</th>
+        <th>Actions</th>
+		<th scope="col"
+			v-for="header in headers"
+			:key="header">
+		    {{ header }}
+		</th>
 		</tr>
 	  </thead>
 	  <tbody>
 		<tr v-for="file_information of files_information">
+          <td>
+          <button type="button" class="btn btn-outline-primary"
+                  v-on:click="file_actions_clicked(file_information)"
+                  >
+            <i class="bi bi-wrench-adjustable"></i>
+          </button>
+          </td>
 		  <td v-for="(value, i) of file_information" v-html="get_formatted_value(i, value)">
-		  </td>
-		  <td>
-			<button type="button" class="btn btn-primary"
-					v-on:click="file_actions_clicked(file_information)"
-					>
-			  Actions
-			</button>
 		  </td>
 		</tr>
 	  </tbody>

--- a/histogram_file_manager/templates/histogram_file_manager/filter_histogram_file_manager.html
+++ b/histogram_file_manager/templates/histogram_file_manager/filter_histogram_file_manager.html
@@ -17,11 +17,11 @@
     <div class="row">
         <div class="col-6">
             Entries greater than
-            {% render_field filter.form.entries_total__gt|add_class:"form-control" %}
+            {% render_field filter.form.entries_total__gt|add_class:"form-control"|attr:"min=0" %}
         </div>
         <div class="col-6">
             Entries less than
-            {% render_field filter.form.entries_total__lt|add_class:"form-control" %}
+            {% render_field filter.form.entries_total__lt|add_class:"form-control"|attr:"min=0" %}
         </div>
     </div>
     Filepath contains

--- a/histogram_file_manager/templates/histogram_file_manager/filter_histogram_file_manager.html
+++ b/histogram_file_manager/templates/histogram_file_manager/filter_histogram_file_manager.html
@@ -1,0 +1,38 @@
+{% load widget_tweaks %}
+
+<h2>Histogram file manager</h2>
+<hr/>
+
+<form id="file_filter_form" action="" method="get" class="form my-1"> 
+    ID
+    {% render_field filter.form.id %}
+    Data era
+    {% render_field filter.form.data_era %}
+    Data dimensionality
+    {% render_field filter.form.data_dimensionality %}
+    Granularity
+    {% render_field filter.form.granularity %}
+    Processing complete
+    {% render_field filter.form.processing_complete|add_class:"form-control" %}
+    <div class="row">
+        <div class="col-6">
+            Entries greater than
+            {% render_field filter.form.entries_total__gt|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            Entries less than
+            {% render_field filter.form.entries_total__lt|add_class:"form-control" %}
+        </div>
+    </div>
+    Filepath contains
+    {% render_field filter.form.filepath__contains|add_class:"form-control" %}
+
+    <div class="d-grid">
+        <button type="submit" id="id_btn_filter" class="btn btn-primary" style="margin-top: 5pt">
+            Filter
+        </button>
+        <a href="{% url 'histogram_file_manager:file_manager' %}" class="btn btn-danger" id="clear-filters" style="margin-top: 5pt">
+            Reset
+        </a>
+    </div>
+</form>

--- a/histogram_file_manager/templates/histogram_file_manager/histogram_file_manager.html
+++ b/histogram_file_manager/templates/histogram_file_manager/histogram_file_manager.html
@@ -24,52 +24,50 @@ Histogram File Manager
 
 {% block content %}
 <div class="container-fluid">
-	<h1 class="my-3" align="center">Histogram File Manager</h1>
-	<h2>Available Histogram Files</h2>
-
 	<!-- Filter form, rendered by django -->
-	<p>
-		<button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#filters-collapse" aria-expanded="false" aria-controls="filters-collapse">
-			Filters
-		</button>
-	</p>
-	<div class="card border-light shadow p-3 bg-white rounded mb-4 collapse" id="filters-collapse">
-		<form id="file_filter_form" method="get" action="">
-			<div class="form-group">
-				{{ filter.form }}
+	<div class="row">
+		<div class="col-lg-3 col-12">
+			<h2>Histogram File Manager</h2>
+			<form id="file_filter_form" method="get" action="">
+				<div class="form-group">
+					{{ filter.form }}
+				</div>
+				<div class="d-grid">
+					<button type="submit" class="btn btn-primary mt-3">Apply filters</button>
+				</div>
+			</form>
+		</div>
+		<div class="col-lg-9 col-12">
+			<h4>Available Histogram Files</h4>
+			<!-- Vue js app -->
+			<div id="app" >
+				<file-table
+					:files_information="files_information"
+					:results_count="results_count"
+					@file-actions-clicked="show_file_actions_modal"
+					:class="{dimmed: waiting_for_data}"
+				>
+				</file-table>
+				<table-pagination
+					:page_next_url="page_next_url"
+								:page_previous_url="page_previous_url"
+									:total_pages="total_pages"
+									:current_page_number="current_page_number"
+								@clicked-previous="fetch_previous_result_page"
+								@clicked-next="fetch_next_result_page"
+								@clicked-specific-page="fetch_specific_result_page" 
+								:class="{dimmed: waiting_for_data}"
+				></table-pagination>
+				<file-actions
+					:file_information="file_information"
+					:is_visible="file_actions_is_visible"
+					:file_id="Number(file_information.id)"
+					:field_choices="{{field_choices}}"
+					@clicked-close="hide_file_actions_modal"
+				>
+				</file-actions>
 			</div>
-			<button type="submit" class="btn btn-primary mt-3">Apply filters</button>
-		</form>
-	</div>
-
-	<!-- Vue js app -->
-	<div id="app" >
-		<file-table
-			:files_information="files_information"
-			:results_count="results_count"
-			@file-actions-clicked="show_file_actions_modal"
-			:class="{dimmed: waiting_for_data}"
-			
-		>
-		</file-table>
-		<table-pagination
-			:page_next_url="page_next_url"
-						:page_previous_url="page_previous_url"
-							:total_pages="total_pages"
-							:current_page_number="current_page_number"
-						@clicked-previous="fetch_previous_result_page"
-						@clicked-next="fetch_next_result_page"
-						@clicked-specific-page="fetch_specific_result_page" 
-						:class="{dimmed: waiting_for_data}"
-		></table-pagination>
-		<file-actions
-			:file_information="file_information"
-			:is_visible="file_actions_is_visible"
-			:file_id="Number(file_information.id)"
-			:field_choices="{{field_choices}}"
-			@clicked-close="hide_file_actions_modal"
-		>
-		</file-actions>
+		</div>
 	</div>
 
 	</ul>	

--- a/histogram_file_manager/templates/histogram_file_manager/histogram_file_manager.html
+++ b/histogram_file_manager/templates/histogram_file_manager/histogram_file_manager.html
@@ -23,7 +23,6 @@ Histogram File Manager
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid">
 	<!-- Filter form, rendered by django -->
 	<div class="row">
 		<div class="col-lg-3 col-12">
@@ -71,9 +70,6 @@ Histogram File Manager
 			</div>
 		</div>
 	</div>
-
-	</ul>	
-</div>
 {% endblock %}
 
 {% block scripts %}

--- a/histogram_file_manager/templates/histogram_file_manager/histogram_file_manager.html
+++ b/histogram_file_manager/templates/histogram_file_manager/histogram_file_manager.html
@@ -27,6 +27,8 @@ Histogram File Manager
 	<!-- Filter form, rendered by django -->
 	<div class="row">
 		<div class="col-lg-3 col-12">
+			{% include "histogram_file_manager/filter_histogram_file_manager.html" %}
+			<!--
 			<h2>Histogram File Manager</h2>
 			<form id="file_filter_form" method="get" action="">
 				<div class="form-group">
@@ -36,9 +38,9 @@ Histogram File Manager
 					<button type="submit" class="btn btn-primary mt-3">Apply filters</button>
 				</div>
 			</form>
+			-->
 		</div>
 		<div class="col-lg-9 col-12">
-			<h4>Available Histogram Files</h4>
 			<!-- Vue js app -->
 			<div id="app" >
 				<file-table

--- a/histograms/api/filters.py
+++ b/histograms/api/filters.py
@@ -71,9 +71,8 @@ class RunHistogramFilter(django_filters.rest_framework.FilterSet):
 class LumisectionHistogram1DFilter(django_filters.FilterSet):
 
     title = django_filters.filters.AllValuesMultipleFilter(
-        widget=forms.SelectMultiple(
+        widget=forms.CheckboxSelectMultiple(
             attrs={
-                "class": "form-control",
                 "size": "10",
             }
         )
@@ -113,9 +112,8 @@ class LumisectionHistogram1DFilter(django_filters.FilterSet):
 class LumisectionHistogram2DFilter(django_filters.FilterSet):
 
     title = django_filters.filters.AllValuesMultipleFilter(
-        widget=forms.SelectMultiple(
+        widget=forms.CheckboxSelectMultiple(
             attrs={
-                "class": "form-control",
                 "size": "10",
             }
         )

--- a/histograms/tables.py
+++ b/histograms/tables.py
@@ -5,7 +5,7 @@ from histograms.models import (
     LumisectionHistogram1D,
     LumisectionHistogram2D,
 )
-
+from django.urls import reverse
 
 class RunHistogramTable(tables.Table):
     run = tables.Column(accessor="run.run_number")
@@ -26,7 +26,7 @@ class RunHistogramTable(tables.Table):
 class OneDimensionHistogramColumn(tables.Column):
     def render(self, record):
         return format_html("""
-        <a href="/visualize/{}/{}/{}">
+        <a href="{}">
         <div id="histogram-{}" style="height: 100pt; width: 200pt;">
             <script>
                 var data = [
@@ -48,12 +48,14 @@ class OneDimensionHistogramColumn(tables.Column):
             </script>
         </div>
         </a>
-        """, record.lumisection.run_id, record.lumisection.ls_number, record.title, record.id, record.data, record.id)
+        """, 
+        reverse("visualize_histogram:visualize_histogram", args=(record.lumisection.run_id, record.lumisection.ls_number, record.title)),
+        record.id, record.data, record.id)
 
 class TwoDimensionHistogramColumn(tables.Column):
     def render(self, record):
         return format_html("""
-        <a href="/visualize/{}/{}/{}">
+        <a href="{}">
         <div id="histogram-{}" style="height: 100pt; width: 200pt;">
             <script>
                 var data = [
@@ -75,7 +77,9 @@ class TwoDimensionHistogramColumn(tables.Column):
             </script>
         </div>
         </a>
-        """, record.lumisection.run.run_number, record.lumisection.ls_number, record.title, record.id, record.data, record.id)
+        """,
+        reverse("visualize_histogram:visualize_histogram", args=(record.lumisection.run_id, record.lumisection.ls_number, record.title)),
+        record.id, record.data, record.id)
 
 class LumisectionHistogram1DTable(tables.Table):
     id = tables.Column()

--- a/histograms/tables.py
+++ b/histograms/tables.py
@@ -26,6 +26,7 @@ class RunHistogramTable(tables.Table):
 class OneDimensionHistogramColumn(tables.Column):
     def render(self, record):
         return format_html("""
+        <a href="/visualize/{}/{}/{}">
         <div id="histogram-{}" style="height: 100pt; width: 200pt;">
             <script>
                 var data = [
@@ -45,11 +46,13 @@ class OneDimensionHistogramColumn(tables.Column):
                 }}, {{staticPlot: true}});
             </script>
         </div>
-        """, record.id, record.data, record.id)
+        </a>
+        """, record.lumisection.run_id, record.lumisection.ls_number, record.title, record.id, record.data, record.id)
 
 class TwoDimensionHistogramColumn(tables.Column):
     def render(self, record):
         return format_html("""
+        <a href="/visualize/{}/{}/{}">
         <div id="histogram-{}" style="height: 100pt; width: 200pt;">
             <script>
                 var data = [
@@ -70,7 +73,8 @@ class TwoDimensionHistogramColumn(tables.Column):
                 }}, {{staticPlot: true}});
             </script>
         </div>
-        """, record.id, record.data, record.id)
+        </a>
+        """, record.lumisection.run.run_number, record.lumisection.ls_number, record.title, record.id, record.data, record.id)
 
 class LumisectionHistogram1DTable(tables.Table):
     id = tables.Column()

--- a/histograms/tables.py
+++ b/histograms/tables.py
@@ -32,7 +32,8 @@ class OneDimensionHistogramColumn(tables.Column):
                 var data = [
                     {{
                         y: {},
-                        type: 'bar'
+                        type: 'bar',
+                        marker: {{color: '#0033A0'}}
                     }}
                 ];
 

--- a/histograms/tables.py
+++ b/histograms/tables.py
@@ -26,7 +26,7 @@ class RunHistogramTable(tables.Table):
 class OneDimensionHistogramColumn(tables.Column):
     def render(self, record):
         return format_html("""
-        <div id="histogram-{}" style="height: 100pt; width: 300pt;">
+        <div id="histogram-{}" style="height: 100pt; width: 200pt;">
             <script>
                 var data = [
                     {{
@@ -50,7 +50,7 @@ class OneDimensionHistogramColumn(tables.Column):
 class TwoDimensionHistogramColumn(tables.Column):
     def render(self, record):
         return format_html("""
-        <div id="histogram-{}" style="height: 100pt; width: 300pt;">
+        <div id="histogram-{}" style="height: 100pt; width: 200pt;">
             <script>
                 var data = [
                     {{
@@ -76,7 +76,7 @@ class LumisectionHistogram1DTable(tables.Table):
     id = tables.Column()
     run = tables.Column(accessor="lumisection.run.run_number")
     lumisection = tables.Column(accessor="lumisection.ls_number")
-    title = tables.Column()
+    title = tables.Column(attrs={"td":{"style" : "min-width: 300px; word-break: break-all;" }})
     entries = tables.Column()
     data = OneDimensionHistogramColumn(verbose_name="Histogram Data")
     paginator_class = tables.LazyPaginator
@@ -91,7 +91,7 @@ class LumisectionHistogram2DTable(tables.Table):
     id = tables.Column()
     run = tables.Column(accessor="lumisection.run.run_number")
     lumisection = tables.Column(accessor="lumisection.ls_number")
-    title = tables.Column()
+    title = tables.Column(attrs={"td":{"style" : "min-width: 300px; word-break: break-all;" }})
     entries = tables.Column()
     data = TwoDimensionHistogramColumn(verbose_name="Histogram Data")
     paginator_class = tables.LazyPaginator

--- a/histograms/templates/histograms/filter_lumisections_1d.html
+++ b/histograms/templates/histograms/filter_lumisections_1d.html
@@ -8,11 +8,11 @@
     <div class="row">
         <div class="col-6">
             From
-            {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
+            {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control"|attr:"min=0" %}
         </div>
         <div class="col-6">
             To
-            {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+            {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control"|attr:"min=0" %}
         </div>
     </div>
     Comma-separated list:
@@ -24,11 +24,11 @@
     <div class="row">
         <div class="col-6">
             From
-            {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
+            {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control"|attr:"min=0" %}
         </div>
         <div class="col-6">
             To
-            {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
+            {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control"|attr:"min=0" %}
         </div>
     </div>
     Comma-separated list
@@ -40,11 +40,11 @@
     <div class="row">
         <div class="col-6">
             Greater than
-            {% render_field filter.form.entries__gte|add_class:"form-control" %}
+            {% render_field filter.form.entries__gte|add_class:"form-control"|attr:"min=0" %}
         </div>
         <div class="col-6">
             Less than
-            {% render_field filter.form.entries__lte|add_class:"form-control" %}
+            {% render_field filter.form.entries__lte|add_class:"form-control"|attr:"min=0" %}
         </div>
     </div>
 

--- a/histograms/templates/histograms/filter_lumisections_1d.html
+++ b/histograms/templates/histograms/filter_lumisections_1d.html
@@ -5,30 +5,48 @@
 
 <form id="ls_histos-filter-form" action="" method="get" class="form my-1">
     <h4>Run number</h4>
-    From: 
-    {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
-    To:
-    {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+    <div class="row">
+        <div class="col-6">
+            From
+            {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            To
+            {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+        </div>
+    </div>
     Comma-separated list:
     {% render_field filter.form.lumisection__run__run_number__in|add_class:"form-control" %}
 
     <hr/>
 
     <h4>Lumisection number</h4>
-    From:
-    {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
-    To:
-    {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
-    Comma-separated list:
+    <div class="row">
+        <div class="col-6">
+            From
+            {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            To
+            {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
+        </div>
+    </div>
+    Comma-separated list
     {% render_field filter.form.lumisection__ls_number__in|add_class:"form-control" %}
 
     <hr/>
 
     <h4>Entries</h4>
-    <strong>>=</strong>:
-    {% render_field filter.form.entries__gte|add_class:"form-control" %}
-    <strong><=</strong>:
-    {% render_field filter.form.entries__lte|add_class:"form-control" %}
+    <div class="row">
+        <div class="col-6">
+            Greater than
+            {% render_field filter.form.entries__gte|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            Less than
+            {% render_field filter.form.entries__lte|add_class:"form-control" %}
+        </div>
+    </div>
 
     <hr/>
 

--- a/histograms/templates/histograms/filter_lumisections_1d.html
+++ b/histograms/templates/histograms/filter_lumisections_1d.html
@@ -55,11 +55,11 @@
         {% render_field filter.form.title %}
     </div>
 
-    <div class="d-grid" style="margin-top: 5pt">
-        <button type="submit" id="id_btn_filter" class="btn btn-primary">
+    <div class="d-grid">
+        <button type="submit" id="id_btn_filter" class="btn btn-primary" style="margin-top: 5pt">
             Filter
         </button>
-        <a href="{% url 'histograms:lumisections_2D_list' %}" class="btn btn-danger" id="clear-filters">
+        <a href="{% url 'histograms:lumisections_2D_list' %}" class="btn btn-danger" id="clear-filters" style="margin-top: 5pt">
             Reset
         </a>
     </div>

--- a/histograms/templates/histograms/filter_lumisections_1d.html
+++ b/histograms/templates/histograms/filter_lumisections_1d.html
@@ -1,4 +1,53 @@
 {% load widget_tweaks %}
+
+<h2>1D lumisection histograms</h2>
+<hr/>
+
+<form id="ls_histos-filter-form" action="" method="get" class="form my-1">
+    <h4>Run number</h4>
+    From: 
+    {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
+    To:
+    {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+    Comma-separated list:
+    {% render_field filter.form.lumisection__run__run_number__in|add_class:"form-control" %}
+
+    <hr/>
+
+    <h4>Lumisection number</h4>
+    From:
+    {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
+    To:
+    {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
+    Comma-separated list:
+    {% render_field filter.form.lumisection__ls_number__in|add_class:"form-control" %}
+
+    <hr/>
+
+    <h4>Entries</h4>
+    <strong>>=</strong>:
+    {% render_field filter.form.entries__gte|add_class:"form-control" %}
+    <strong><=</strong>:
+    {% render_field filter.form.entries__lte|add_class:"form-control" %}
+
+    <hr/>
+
+    <h4>Title</h4>
+    <div style="overflow-y: scroll; height: 400px; word-break: break-all;">
+        {% render_field filter.form.title %}
+    </div>
+
+    <div class="d-grid" style="margin-top: 5pt">
+        <button type="submit" id="id_btn_filter" class="btn btn-primary">
+            Filter
+        </button>
+        <a href="{% url 'histograms:lumisections_2D_list' %}" class="btn btn-danger" id="clear-filters">
+            Reset
+        </a>
+    </div>
+</form>
+
+<!--
 <div class="container">
     <div class="card border-light shadow p-3 bg-white rounded mb-4" style="margin: 0 auto 10px; width: 800px;">
         <form id="ls_histos-filter-form" action="" method="get" class="form my-1">
@@ -186,3 +235,4 @@
             </div>
 
         </form>
+    -->

--- a/histograms/templates/histograms/filter_lumisections_2d.html
+++ b/histograms/templates/histograms/filter_lumisections_2d.html
@@ -56,10 +56,10 @@
     </div>
 
     <div class="d-grid" style="margin-top: 5pt">
-        <button type="submit" id="id_btn_filter" class="btn btn-primary">
+        <button type="submit" id="id_btn_filter" class="btn btn-primary" style="margin-top: 5pt">
             Filter
         </button>
-        <a href="{% url 'histograms:lumisections_2D_list' %}" class="btn btn-danger" id="clear-filters">
+        <a href="{% url 'histograms:lumisections_2D_list' %}" class="btn btn-danger" id="clear-filters" style="margin-top: 5pt">
             Reset
         </a>
     </div>

--- a/histograms/templates/histograms/filter_lumisections_2d.html
+++ b/histograms/templates/histograms/filter_lumisections_2d.html
@@ -5,30 +5,48 @@
 
 <form id="ls_histos-filter-form" action="" method="get" class="form my-1">
     <h4>Run number</h4>
-    From: 
-    {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
-    To:
-    {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+    <div class="row">
+        <div class="col-6">
+            From
+            {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            To
+            {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+        </div>
+    </div>
     Comma-separated list:
     {% render_field filter.form.lumisection__run__run_number__in|add_class:"form-control" %}
 
     <hr/>
 
     <h4>Lumisection number</h4>
-    From:
-    {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
-    To:
-    {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
-    Comma-separated list:
+    <div class="row">
+        <div class="col-6">
+            From
+            {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            To
+            {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
+        </div>
+    </div>
+    Comma-separated list
     {% render_field filter.form.lumisection__ls_number__in|add_class:"form-control" %}
 
     <hr/>
 
     <h4>Entries</h4>
-    <strong>>=</strong>:
-    {% render_field filter.form.entries__gte|add_class:"form-control" %}
-    <strong><=</strong>:
-    {% render_field filter.form.entries__lte|add_class:"form-control" %}
+    <div class="row">
+        <div class="col-6">
+            Greater than
+            {% render_field filter.form.entries__gte|add_class:"form-control" %}
+        </div>
+        <div class="col-6">
+            Less than
+            {% render_field filter.form.entries__lte|add_class:"form-control" %}
+        </div>
+    </div>
 
     <hr/>
 

--- a/histograms/templates/histograms/filter_lumisections_2d.html
+++ b/histograms/templates/histograms/filter_lumisections_2d.html
@@ -1,4 +1,53 @@
 {% load widget_tweaks %}
+
+<h2>2D lumisection histograms</h2>
+<hr/>
+
+<form id="ls_histos-filter-form" action="" method="get" class="form my-1">
+    <h4>Run number</h4>
+    From: 
+    {% render_field filter.form.lumisection__run__run_number__gte|add_class:"form-control" %}
+    To:
+    {% render_field filter.form.lumisection__run__run_number__lte|add_class:"form-control" %}
+    Comma-separated list:
+    {% render_field filter.form.lumisection__run__run_number__in|add_class:"form-control" %}
+
+    <hr/>
+
+    <h4>Lumisection number</h4>
+    From:
+    {% render_field filter.form.lumisection__ls_number__gte|add_class:"form-control" %}
+    To:
+    {% render_field filter.form.lumisection__ls_number__lte|add_class:"form-control" %}
+    Comma-separated list:
+    {% render_field filter.form.lumisection__ls_number__in|add_class:"form-control" %}
+
+    <hr/>
+
+    <h4>Entries</h4>
+    <strong>>=</strong>:
+    {% render_field filter.form.entries__gte|add_class:"form-control" %}
+    <strong><=</strong>:
+    {% render_field filter.form.entries__lte|add_class:"form-control" %}
+
+    <hr/>
+
+    <h4>Title</h4>
+    <div style="overflow-y: scroll; height: 400px; word-break: break-all;">
+        {% render_field filter.form.title %}
+    </div>
+
+    <div class="d-grid" style="margin-top: 5pt">
+        <button type="submit" id="id_btn_filter" class="btn btn-primary">
+            Filter
+        </button>
+        <a href="{% url 'histograms:lumisections_2D_list' %}" class="btn btn-danger" id="clear-filters">
+            Reset
+        </a>
+    </div>
+</form>
+
+<!--
 <div class="container">
     <div class="card border-light shadow p-3 bg-white rounded mb-4" style="margin: 0 auto 10px; width: 800px;">
         <form id="ls_histos-filter-form" action="" method="get" class="form my-1">
@@ -186,3 +235,4 @@
             </div>
 
         </form>
+-->

--- a/histograms/templates/histograms/listLumisectionHistos1D.html
+++ b/histograms/templates/histograms/listLumisectionHistos1D.html
@@ -24,7 +24,7 @@ lumisection 1D histograms
         <div class="col-lg-9 col-12">
             {% if lumisectionHistos1D_table %}
             <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-            <div class="overflow-auto px-3" id="style-1">
+            <div class="overflow-auto" id="style-1">
                 {% render_table lumisectionHistos1D_table 'histograms/bootstrap.html' %}
             </div>
             {% else %}

--- a/histograms/templates/histograms/listLumisectionHistos1D.html
+++ b/histograms/templates/histograms/listLumisectionHistos1D.html
@@ -24,7 +24,7 @@ lumisection 1D histograms
         <div class="col-lg-9 col-12">
             {% if lumisectionHistos1D_table %}
             <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-            <div class="overflow-auto px-3 bg-white" id="style-1">
+            <div class="overflow-auto px-3" id="style-1">
                 {% render_table lumisectionHistos1D_table 'histograms/bootstrap.html' %}
             </div>
             {% else %}

--- a/histograms/templates/histograms/listLumisectionHistos1D.html
+++ b/histograms/templates/histograms/listLumisectionHistos1D.html
@@ -12,23 +12,26 @@ lumisection 1D histograms
 {% block content %}
     {% load render_table from django_tables2 %}
     {% load bootstrap3 %}
-    <h1 class="my-3" align="center">1D Histograms for Lumisection based data</h1>
-    <div class="container">
-        {% if filter %}
-            {% include "histograms/filter_lumisections_1d.html" %}
-        {% else %}
-            <div class="alert alert-danger" role="alert">No Filter found.</div>
-        {% endif %}
-    </div>
 
-    {% if lumisectionHistos1D_table %}
-    <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-    <div class="overflow-auto px-3 bg-white" id="style-1">
-        {% render_table lumisectionHistos1D_table 'histograms/bootstrap.html' %}
+    <div class="row">
+        <div class="col-lg-3 col-12">
+            {% if filter %}
+                {% include "histograms/filter_lumisections_1d.html" %}
+            {% else %}
+                <div class="alert alert-danger" role="alert">No Filter found.</div>
+            {% endif %}
+        </div>
+        <div class="col-lg-9 col-12">
+            {% if lumisectionHistos1D_table %}
+            <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
+            <div class="overflow-auto px-3 bg-white" id="style-1">
+                {% render_table lumisectionHistos1D_table 'histograms/bootstrap.html' %}
+            </div>
+            {% else %}
+                <div class="alert alert-danger" role="alert">No Table found.</div>
+            {% endif %}
+        </div>
     </div>
-    {% else %}
-        <div class="alert alert-danger" role="alert">No Table found.</div>
-    {% endif %}
 
 
 {% endblock content %}

--- a/histograms/templates/histograms/listLumisectionHistos2D.html
+++ b/histograms/templates/histograms/listLumisectionHistos2D.html
@@ -12,24 +12,26 @@ lumisection 2D histograms
 {% block content %}
     {% load render_table from django_tables2 %}
     {% load bootstrap3 %}
-    <h1 class="my-3" align="center">2D Histograms for Lumisection based data</h1>
-    <div class="container">
-        {% if filter %}
-            {% include "histograms/filter_lumisections_2d.html" %}
-        {% else %}
-            <div class="alert alert-danger" role="alert">No Filter found.</div>
-        {% endif %}
-    </div>
 
-    {% if lumisectionHistos2D_table %}
-    <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-    <div class="overflow-auto px-3 bg-white" id="style-1">
-        {% render_table lumisectionHistos2D_table 'histograms/bootstrap.html'%}
+    <div class="row">
+        <div class="col-lg-3 col-12">
+            {% if filter %}
+                {% include "histograms/filter_lumisections_2d.html" %}
+            {% else %}
+                <div class="alert alert-danger" role="alert">No Filter found.</div>
+            {% endif %}
+        </div>
+        <div class="col-lg-9 col-12">
+            {% if lumisectionHistos2D_table %}
+            <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
+            <div class="overflow-auto px-3 bg-white" id="style-1">
+                {% render_table lumisectionHistos2D_table 'histograms/bootstrap.html'%}
+            </div>
+            {% else %}
+                <div class="alert alert-danger" role="alert">No Table found.</div>
+            {% endif %}
+        </div>
     </div>
-    {% else %}
-        <div class="alert alert-danger" role="alert">No Table found.</div>
-    {% endif %}
-
 
 {% endblock content %}
 

--- a/histograms/templates/histograms/listLumisectionHistos2D.html
+++ b/histograms/templates/histograms/listLumisectionHistos2D.html
@@ -24,7 +24,7 @@ lumisection 2D histograms
         <div class="col-lg-9 col-12">
             {% if lumisectionHistos2D_table %}
             <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-            <div class="overflow-auto px-3 bg-white" id="style-1">
+            <div class="overflow-auto px-3" id="style-1">
                 {% render_table lumisectionHistos2D_table 'histograms/bootstrap.html'%}
             </div>
             {% else %}

--- a/histograms/templates/histograms/listLumisectionHistos2D.html
+++ b/histograms/templates/histograms/listLumisectionHistos2D.html
@@ -24,7 +24,7 @@ lumisection 2D histograms
         <div class="col-lg-9 col-12">
             {% if lumisectionHistos2D_table %}
             <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-            <div class="overflow-auto px-3" id="style-1">
+            <div class="overflow-auto" id="style-1">
                 {% render_table lumisectionHistos2D_table 'histograms/bootstrap.html'%}
             </div>
             {% else %}

--- a/histograms/templates/histograms/listRunHistos1D.html
+++ b/histograms/templates/histograms/listRunHistos1D.html
@@ -15,11 +15,8 @@ Run histograms
     
     <div class="row">
         <div class="col-lg-3 col-12">
-            {% if filter %}
-                {% include "run_histos/filter.html" %}
-            {% else %}
-                <div class="alert alert-danger" role="alert">No Filter found.</div>
-            {% endif %}
+            <h2>Under construction</h2>
+            Please come back later.
         </div>
         <div class="col-lg-9 col-12">
             {% if runHistos_table %}

--- a/histograms/templates/histograms/listRunHistos1D.html
+++ b/histograms/templates/histograms/listRunHistos1D.html
@@ -12,23 +12,26 @@ Run histograms
 {% block content %}
     {% load render_table from django_tables2 %}
     {% load bootstrap3 %}
-    <h1 class="my-3" align="center">1D Histograms for Run based data</h1>
-    <div class="container">
-        {% if filter %}
-            {% include "run_histos/filter.html" %}
-        {% else %}
-            <div class="alert alert-danger" role="alert">No Filter found.</div>
-        {% endif %}
+    
+    <div class="row">
+        <div class="col-lg-3 col-12">
+            {% if filter %}
+                {% include "run_histos/filter.html" %}
+            {% else %}
+                <div class="alert alert-danger" role="alert">No Filter found.</div>
+            {% endif %}
+        </div>
+        <div class="col-lg-9 col-12">
+            {% if runHistos_table %}
+            <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
+            <div class="overflow-auto px-3" id="style-1">
+                {% render_table runHistos_table 'django_tables2/bootstrap.html'%}
+            </div>
+            {% else %}
+                <div class="alert alert-danger" role="alert">No Table found.</div>
+            {% endif %}
+        </div>
     </div>
-
-    {% if runHistos_table %}
-    <!-- div class="overflow-auto scrollbar border-light shadow m-1 bg-white" id="style-1"-->
-    <div class="overflow-auto px-3 bg-white" id="style-1">
-        {% render_table runHistos_table 'django_tables2/bootstrap.html'%}
-    </div>
-    {% else %}
-        <div class="alert alert-danger" role="alert">No Table found.</div>
-    {% endif %}
 
 
 {% endblock content %}

--- a/mlp/settings.py
+++ b/mlp/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "dataset_tables.apps.DatasetTablesConfig",
     "histograms",
     "histogram_file_manager",
+    "visualize_histogram",
     "challenge",
     "data_taking_objects",
     "data_taking_certification",

--- a/mlp/urls.py
+++ b/mlp/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
     path("challenge/", include("challenge.urls")),
     path("admin/", admin.site.urls),
     path("histogram_file_manager/", include("histogram_file_manager.urls")),
+    path("visualize/", include("visualize_histogram.urls")),
     path("api/", include((router.urls, "api"), namespace="api"), name="api"),
     path(
         "openapi",

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
       {% include "navbar_top.html" %}
 
       <!-- Page Content -->
-      <div class='container container-main-page'>
+      <div class='container-fluid container-main-page'>
         {% block content %}
           Default Bootstrap Container.
         {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 
     <head>
 
@@ -12,20 +12,26 @@
     <!-- Custom CSS -->
     <link rel='stylesheet' type='text/css' href={% static 'css/style.css' %}>
 
-    <!-- Bootstrap CSS -->
+    <!-- Bootstrap CSS 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" 
 			  rel="stylesheet" 
 			  integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" 
 			  crossorigin="anonymous"
     >
+  -->
 
-    <!-- Bootstrap 5 -->
-    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>			
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>			
+
+  <!-- Bootstrap 5 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
 				 integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
 				 crossorigin="anonymous"
     >
-    </script>
+    </script>-->
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
+
 
     <!-- Altair -->
     <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,8 +9,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <!-- Custom CSS -->
-    <link rel='stylesheet' type='text/css' href={% static 'css/style.css' %}>
 
     <!-- Bootstrap CSS 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" 
@@ -31,6 +29,9 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
+
+    <!-- Custom CSS -->
+    <link rel='stylesheet' type='text/css' href={% static 'css/style.css' %}>
 
 
     <!-- Altair -->
@@ -57,7 +58,7 @@
       {% include "navbar_top.html" %}
 
       <!-- Page Content -->
-      <div class='container-fluid container-main-page'>
+      <div class='container-main-page'>
         {% block content %}
           Default Bootstrap Container.
         {% endblock %}

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -1,5 +1,5 @@
 {% load static %}
-<nav class="navbar navbar-fixed-top navbar-expand-lg navbar-dark bg-dark px-4">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="/">
 			<img src="{% static 'img/favicon.png' %}" width="30" height="30" alt="" title="My Little Playground">

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -37,7 +37,7 @@
 						Discover
 					</a>
 					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<a class="dropdown-item" href="{% url 'visualize_histogram:visualize' %}">Visualise histogram</a>
+						<a class="dropdown-item" href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">Visualise histogram</a>
 						<a class="dropdown-item" href="{% url 'histograms:run-histograms-view' %}">Run Histograms</a>
 						<a class="dropdown-item" href="#">Movie</a>
 						<!--<hr class="dropdown-divider">-->

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -39,7 +39,7 @@
 					</a>
 					<div class="dropdown-menu shadow" aria-labelledby="navbarDropdown">
 						<a class="dropdown-item" href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">Visualise histogram</a>
-						<a class="dropdown-item" href="{% url 'histograms:run-histograms-view' %}">Run Histograms</a>
+						<!--<a class="dropdown-item" href="{% url 'histograms:run-histograms-view' %}">Run Histograms</a>-->
 						<a class="dropdown-item" href="#">Movie</a>
 						<hr class="dropdown-divider">
 						<a class="dropdown-item" href="{% url 'data_taking_certification:run-certification-view' %}">Run Certification</a>
@@ -57,6 +57,10 @@
 						<a class="dropdown-item" href="#">Your models</a>
 						<!--<hr class="dropdown-divider">-->
 					</div>
+				</li>
+
+				<li class="nav-item active">
+					<a class="nav-link" href="{% url 'api:api-root' %}">APIs</a>
 				</li>
 
 				<!--

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!--<nav class="navbar navbar-expand-lg px-4" style="background-color: #cdd6ed;">-->
-<nav class="navbar navbar-expand-lg px-4 bg-dark navbar-dark">
+<nav class="navbar navbar-expand-lg px-4 navbar-dark">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="/">
 			<img src="{% static 'img/favicon.png' %}" width="30" height="30" alt="" title="My Little Playground">
@@ -41,6 +41,9 @@
 						<a class="dropdown-item" href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">Visualise histogram</a>
 						<a class="dropdown-item" href="{% url 'histograms:run-histograms-view' %}">Run Histograms</a>
 						<a class="dropdown-item" href="#">Movie</a>
+						<hr class="dropdown-divider">
+						<a class="dropdown-item" href="{% url 'data_taking_certification:run-certification-view' %}">Run Certification</a>
+						<a class="dropdown-item" href="{% url 'data_taking_certification:lumisection-certification-view' %}">Lumisection Certification</a>
 						<!--<hr class="dropdown-divider">-->
 					</div>
 				</li>

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -1,13 +1,13 @@
 {% load static %}
 <!--<nav class="navbar navbar-expand-lg px-4" style="background-color: #cdd6ed;">-->
-<nav class="navbar navbar-expand-lg px-4 navbar-dark">
+<nav class="navbar fixed-top navbar-expand-lg px-4 navbar-dark">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="/">
 			<img src="{% static 'img/favicon.png' %}" width="30" height="30" alt="" title="My Little Playground">
 			DQM Playground
 		</a>
 
-		<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+		<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation" data-bs-theme="dark">
 			<span class="navbar-toggler-icon"></span>
 		</button>
 

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -1,5 +1,6 @@
 {% load static %}
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4">
+<!--<nav class="navbar navbar-expand-lg px-4" style="background-color: #cdd6ed;">-->
+<nav class="navbar navbar-expand-lg px-4 bg-dark navbar-dark">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="/">
 			<img src="{% static 'img/favicon.png' %}" width="30" height="30" alt="" title="My Little Playground">
@@ -19,10 +20,10 @@
 					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						Manage
 					</a>
-					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+					<div class="dropdown-menu shadow" aria-labelledby="navbarDropdown">
 						<a class="dropdown-item" href="{% url 'histogram_file_manager:file_manager' %}">Histogram files</a>
 						<!--<hr class="dropdown-divider">-->
-						<a class="dropdown-item" href="{% url 'histograms:run-histograms-plots-view' %}">Run Histograms Plots</a>
+						<a class="dropdown-item" href="{% url 'histograms:run-histograms-plots-view' %}">Run Histograms</a>
 						<!-- This should go under Discover. -->
 						<!--
 						-->
@@ -36,7 +37,7 @@
 					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						Discover
 					</a>
-					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+					<div class="dropdown-menu shadow" aria-labelledby="navbarDropdown">
 						<a class="dropdown-item" href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">Visualise histogram</a>
 						<a class="dropdown-item" href="{% url 'histograms:run-histograms-view' %}">Run Histograms</a>
 						<a class="dropdown-item" href="#">Movie</a>
@@ -48,7 +49,7 @@
 					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						Challenge
 					</a>
-					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+					<div class="dropdown-menu shadow" aria-labelledby="navbarDropdown">
 						<a class="dropdown-item" href="#">Tasks</a>
 						<a class="dropdown-item" href="#">Your models</a>
 						<!--<hr class="dropdown-divider">-->
@@ -132,7 +133,7 @@
 					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true", aria-expanded="false">
 						{% if user.first_name %}{{ user.first_name }} {{ user.last_name }}{% else %}{{ user.username }}{% endif %}
 					</a>
-					<div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+					<div class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="navbarDropdown">
 						<a class="dropdown-item disabled" aria-disabled="true">Logged in as {{ user.username }}</a>
 						<a class="dropdown-item" href="{% url 'home:logout' %}">Log out</a>
 					</div>

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -23,7 +23,7 @@
 					<div class="dropdown-menu shadow" aria-labelledby="navbarDropdown">
 						<a class="dropdown-item" href="{% url 'histogram_file_manager:file_manager' %}">Histogram files</a>
 						<!--<hr class="dropdown-divider">-->
-						<a class="dropdown-item" href="{% url 'histograms:run-histograms-plots-view' %}">Run Histograms</a>
+						<a class="dropdown-item" href="{% url 'histograms:runs_list' %}">Run Histograms</a>
 						<!-- This should go under Discover. -->
 						<!--
 						-->

--- a/templates/navbar_top.html
+++ b/templates/navbar_top.html
@@ -1,5 +1,5 @@
 {% load static %}
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4">
+<nav class="navbar navbar-fixed-top navbar-expand-lg navbar-dark bg-dark px-4">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="/">
 			<img src="{% static 'img/favicon.png' %}" width="30" height="30" alt="" title="My Little Playground">
@@ -13,12 +13,49 @@
 		<div class="collapse navbar-collapse" id="navbarNav">
 			<ul class="navbar-nav">
 
-				<li class="nav-item {%if request.path == path_to_home%} active {% endif %}">
-					<a class="nav-link" href="{% url 'home:home' %}">Home</a>
-				</li>
-
 				{% if request.user.is_authenticated%}
 
+				<li class="nav-item dropdown">
+					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						Manage
+					</a>
+					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+						<a class="dropdown-item" href="{% url 'histogram_file_manager:file_manager' %}">Histogram files</a>
+						<!--<hr class="dropdown-divider">-->
+						<a class="dropdown-item" href="{% url 'histograms:run-histograms-plots-view' %}">Run Histograms Plots</a>
+						<!-- This should go under Discover. -->
+						<!--
+						-->
+						<!--<hr class="dropdown-divider">-->
+						<a class="dropdown-item" href="{% url 'histograms:lumisections_1D_list' %}">1D Lumisection histograms</a>
+						<a class="dropdown-item" href="{% url 'histograms:lumisections_2D_list' %}">2D Lumisection Histograms</a>
+					</div>
+				</li>
+
+				<li class="nav-item dropdown">
+					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						Discover
+					</a>
+					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+						<a class="dropdown-item" href="{% url 'visualize_histogram:visualize' %}">Visualise histogram</a>
+						<a class="dropdown-item" href="{% url 'histograms:run-histograms-view' %}">Run Histograms</a>
+						<a class="dropdown-item" href="#">Movie</a>
+						<!--<hr class="dropdown-divider">-->
+					</div>
+				</li>
+
+				<li class="nav-item dropdown">
+					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						Challenge
+					</a>
+					<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+						<a class="dropdown-item" href="#">Tasks</a>
+						<a class="dropdown-item" href="#">Your models</a>
+						<!--<hr class="dropdown-divider">-->
+					</div>
+				</li>
+
+				<!--
 				<li class="nav-item dropdown">
 					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						Granularity
@@ -82,6 +119,7 @@
 				<li class="nav-item {%if request.path == path_to_whatever%} active {% endif %}">
 					<a class="nav-link" href="{% url 'api:api-root' %}">APIs</a>
 				</li>
+				-->
 
 				{% endif %}
 			</ul>

--- a/visualize_histogram/admin.py
+++ b/visualize_histogram/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/visualize_histogram/apps.py
+++ b/visualize_histogram/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class VisualizeHistogramConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "visualize_histogram"

--- a/visualize_histogram/forms.py
+++ b/visualize_histogram/forms.py
@@ -1,0 +1,15 @@
+from django import forms
+
+class QuickJumpForm(forms.Form):
+    runnr = forms.IntegerField(
+        required=True, 
+        widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+    lumisection = forms.IntegerField(
+        required=True, 
+        widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+    title = forms.CharField(
+        required=True, 
+        widget=forms.TextInput(attrs={"class": "form-control"})
+    )

--- a/visualize_histogram/models.py
+++ b/visualize_histogram/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/visualize_histogram/templates/visualize_histogram/visualize_firstpage.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_firstpage.html
@@ -1,0 +1,26 @@
+{%extends 'base.html' %}
+
+{% block content %}
+<h2>Jump quickly</h2>
+<form action="" method="GET" class="row">
+    <div class="col-6 col-lg-1">
+        <label for="formQuickJumpRun">Run</label>
+        {{ form.runnr }}
+    </div>
+    <div class="col-6 col-lg-1">
+        <label for="formQuickJumpLS">Lumisection</label>
+        {{ form.lumisection }}
+    </div>
+    <div class="col-12 col-lg-9">
+        <label for="formQuickJumpTitle">Title</label>
+        {{ form.title }}
+    </div>
+    <div class="col-12 col-lg-1">
+        <br>
+        <div class="d-grid">
+            <button class="btn btn-primary" type="submit">Go</button>
+        </div>
+    </div>
+</form>
+
+{% endblock %}

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -11,36 +11,72 @@ Visualize histograms
 {% endblock %}
 
 {% block maincontent %}
-<div id="hist-id-12345" style="height: auto">
+{% if data %}
+<div id="histogram-show" style="height: auto">
     <script>
-        var x = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 3.0, 1.0, 9.0, 26.0, 68.0, 87.0, 161.0, 303.0, 589.0, 1056.0, 1702.0, 2509.0, 3273.0, 3827.0, 4188.0, 4116.0, 3921.0, 3547.0, 3150.0, 2639.0, 2426.0, 1975.0, 1671.0, 1496.0, 1261.0, 1160.0, 979.0, 816.0, 763.0, 719.0, 658.0, 607.0, 527.0, 501.0, 449.0, 433.0, 369.0, 370.0, 338.0, 319.0, 316.0, 266.0, 239.0, 226.0, 233.0, 233.0, 200.0, 175.0, 182.0, 160.0, 137.0, 157.0, 128.0, 134.0, 96.0, 99.0, 106.0, 97.0, 86.0, 84.0, 91.0, 72.0, 67.0, 63.0, 65.0, 70.0, 70.0, 54.0, 60.0, 65.0, 47.0, 60.0, 38.0, 55.0, 35.0, 52.0, 38.0, 39.0, 26.0, 37.0, 30.0, 23.0, 21.0, 30.0, 16.0, 18.0, 15.0, 26.0, 17.0, 15.0, 14.0, 710.0];
         var trace = {
-            y: x,
+            x: {{ bins }},
+            y: {{ data }},
             type: 'bar'
         };
         var data = [trace];
 
-        Plotly.newPlot('hist-id-12345', data, 
+        Plotly.newPlot('histogram-show', data, 
         {
             bargap: 0, 
             paper_bgcolor: 'rgba(0,0,0,0)',
             plot_bgcolor: 'rgba(0,0,0,0)',
             title: {
-                text:'Run 297178',
+                text:'{{ title }}<br>Run {{ runnr }}, lumisection {{ lumisection }}',
                 xref: 'paper',
-                x: 0,
-                font: {
-                    size: 40
-                }
+                x: 0
             }
         }, {responsive: true});
     </script>
 </div>
+{% elif data2d %}
+<div id="histogram-show" style="height: 700px">
+    <script>
+        var data = [
+            {
+                z: {{ data2d }},
+                x: {{ xbins }},
+                y: {{ ybins }},
+                type: 'heatmap',
+                colorscale: 'Viridis'
+            }
+        ];
+
+        Plotly.newPlot('histogram-show', data, 
+        {
+            paper_bgcolor: 'rgba(0,0,0,0)',
+            plot_bgcolor: 'rgba(0,0,0,0)',
+            title: {
+                text:'{{ title }}<br>Run {{ runnr }}, lumisection {{ lumisection }}',
+                xref: 'paper',
+                x: 0
+            }
+        });
+    </script>
+</div>
+{% else %}
+<div class="alert alert-danger">
+    <h2>No histogram found.</h2>
+    Check the spelling of the above URL and try again. Based on the URL, here are the queries you have requested:
+    <ol>
+        <li>Run: {{ runnr }}</li>
+        <li>Lumisection: {{ lumisection }}</li>
+        <li>Title: {{ title }}</li>
+    </ol>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block sidebar %}
 <h2>More from OMS</h2>
-This is a dummy content showing a rough design of the visualization page. 
+<a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{runnr}}">Run {{runnr}}</a>
+<a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{runnr}}">L1 rates from run {{runnr}}</a>
+<a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{runnr}}">HLT rates from run {{runnr}}</a>
 
 {% endblock %}
 

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block title %}
-Visualize histograms
+{{ title }}, run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}
 {% endblock %}
 
 {% block maincontent %}
@@ -27,7 +27,7 @@ Visualize histograms
             paper_bgcolor: 'rgba(0,0,0,0)',
             plot_bgcolor: 'rgba(0,0,0,0)',
             title: {
-                text:'{{ title }}<br>Run {{ runnr }}, lumisection {{ lumisection }}',
+                text:'{{ title }}<br>Run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}',
                 xref: 'paper',
                 x: 0
             }
@@ -52,7 +52,7 @@ Visualize histograms
             paper_bgcolor: 'rgba(0,0,0,0)',
             plot_bgcolor: 'rgba(0,0,0,0)',
             title: {
-                text:'{{ title }}<br>Run {{ runnr }}, lumisection {{ lumisection }}',
+                text:'{{ title }}<br>Run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}',
                 xref: 'paper',
                 x: 0
             }

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -12,7 +12,7 @@ Visualize histograms
 
 {% block maincontent %}
 {% if data %}
-<div id="histogram-show" style="height: auto">
+<div id="histogram-show" style="height: 700px;">
     <script>
         var trace = {
             x: {{ bins }},
@@ -35,7 +35,7 @@ Visualize histograms
     </script>
 </div>
 {% elif data2d %}
-<div id="histogram-show" style="height: 700px">
+<div id="histogram-show" style="height: 700px;">
     <script>
         var data = [
             {
@@ -56,7 +56,7 @@ Visualize histograms
                 xref: 'paper',
                 x: 0
             }
-        });
+        }, {responsive: true});
     </script>
 </div>
 {% else %}
@@ -64,9 +64,9 @@ Visualize histograms
     <h2>No histogram found.</h2>
     Check the spelling of the above URL and try again. Based on the URL, here are the queries you have requested:
     <ol>
-        <li>Run: {{ runnr }}</li>
-        <li>Lumisection: {{ lumisection }}</li>
-        <li>Title: {{ title }}</li>
+        <li>Run: <code>{{runnr}}</code></li>
+        {% if lumisection %}<li>Lumisection: <code>{{lumisection}}</code></li>{% endif %}
+        <li>Title: <code>{{title}}</code></li>
     </ol>
 </div>
 {% endif %}

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -12,6 +12,7 @@
 
 {% block maincontent %}
 {% if data %}
+<i class="bi bi-arrow-left"></i> <a href="{% url 'data_taking_objects:run-view' run_number=runnr %}">Run {{ runnr }}</a>, <a href="{% url 'data_taking_objects:lumisection-view' run_number=runnr lumi_number=lumisection %}">lumisection {{ lumisection }}</a>
 <div id="histogram-show" style="height: 80vh;">
     <script>
         var trace = {
@@ -36,6 +37,7 @@
     </script>
 </div>
 {% elif data2d %}
+<i class="bi bi-arrow-left"></i> <a href="{% url 'data_taking_objects:run-view' run_number=runnr %}">Run {{ runnr }}</a>, <a href="{% url 'data_taking_objects:lumisection-view' run_number=runnr lumi_number=lumisection %}">lumisection {{ lumisection }}</a>
 <div id="histogram-show" style="height: 80vh;">
     <script>
         var data = [
@@ -69,6 +71,7 @@
         {% if lumisection %}<li>Lumisection: <code>{{lumisection}}</code></li>{% endif %}
         <li>Title: <code>{{title}}</code></li>
     </ol>
+    <a class="btn btn-primary" href="{% url 'visualize_histogram:visualize_histogram_dummy' %}"><i class="bi bi-arrow-left"></i> Go back</a>
 </div>
 {% endif %}
 {% endblock %}

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -12,56 +12,61 @@
 
 {% block maincontent %}
 {% if data %}
-<i class="bi bi-arrow-left"></i> <a href="{% url 'data_taking_objects:run-view' run_number=runnr %}">Run {{ runnr }}</a>, <a href="{% url 'data_taking_objects:lumisection-view' run_number=runnr lumi_number=lumisection %}">lumisection {{ lumisection }}</a>
-<div id="histogram-show" style="height: 80vh;">
-    <script>
-        var trace = {
-            x: {{ bins }},
-            y: {{ data }},
-            type: 'bar',
-            marker: {color: '#0033A0'}
-        };
-        var data = [trace];
+<i class="bi bi-chevron-left"></i> <a href="{% url 'visualize_histogram:visualize_histogram_dummy' %}">All runs</a> 
+/ <a href="{% url 'visualize_histogram:redirect_run' runnr=runnr %}">Run {{ runnr }}</a> 
+/ <a href="{% url 'data_taking_objects:lumisection-view' run_number=runnr lumi_number=lumisection %}">lumisection {{ lumisection }}</a>
 
-        Plotly.newPlot('histogram-show', data, 
-        {
-            bargap: 0, 
-            paper_bgcolor: 'rgba(0,0,0,0)',
-            plot_bgcolor: 'rgba(0,0,0,0)',
-            title: {
-                text:'{{ title }}<br>Run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}',
-                xref: 'paper',
-                x: 0
-            }
-        }, {responsive: true});
-    </script>
-</div>
-{% elif data2d %}
-<i class="bi bi-arrow-left"></i> <a href="{% url 'data_taking_objects:run-view' run_number=runnr %}">Run {{ runnr }}</a>, <a href="{% url 'data_taking_objects:lumisection-view' run_number=runnr lumi_number=lumisection %}">lumisection {{ lumisection }}</a>
-<div id="histogram-show" style="height: 80vh;">
-    <script>
-        var data = [
+    {% if is2d %}
+    <div id="histogram-show" style="height: 80vh;">
+        <script>
+            var data = [
+                {
+                    z: {{ data }},
+                    x: {{ xbins }},
+                    y: {{ ybins }},
+                    type: 'heatmap',
+                    colorscale: 'Viridis'
+                }
+            ];
+
+            Plotly.newPlot('histogram-show', data, 
             {
-                z: {{ data2d }},
-                x: {{ xbins }},
-                y: {{ ybins }},
-                type: 'heatmap',
-                colorscale: 'Viridis'
-            }
-        ];
+                paper_bgcolor: 'rgba(0,0,0,0)',
+                plot_bgcolor: 'rgba(0,0,0,0)',
+                title: {
+                    text:'{{ title }}<br>Run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}',
+                    xref: 'paper',
+                    x: 0
+                }
+            }, {responsive: true});
+        </script>
+    </div>
+    {% else %}
+    <div id="histogram-show" style="height: 80vh;">
+        <script>
+            var trace = {
+                x: {{ bins }},
+                y: {{ data }},
+                type: 'bar',
+                marker: {color: '#0033A0'}
+            };
+            var data = [trace];
 
-        Plotly.newPlot('histogram-show', data, 
-        {
-            paper_bgcolor: 'rgba(0,0,0,0)',
-            plot_bgcolor: 'rgba(0,0,0,0)',
-            title: {
-                text:'{{ title }}<br>Run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}',
-                xref: 'paper',
-                x: 0
-            }
-        }, {responsive: true});
-    </script>
-</div>
+            Plotly.newPlot('histogram-show', data, 
+            {
+                bargap: 0, 
+                paper_bgcolor: 'rgba(0,0,0,0)',
+                plot_bgcolor: 'rgba(0,0,0,0)',
+                title: {
+                    text:'{{ title }}<br>Run {{ runnr }}{% if lumisection %}, lumisection {{ lumisection }}{% endif %}',
+                    xref: 'paper',
+                    x: 0
+                }
+            }, {responsive: true});
+        </script>
+    </div>
+    {% endif %}
+
 {% else %}
 <div class="alert alert-danger">
     <h2>No histogram found</h2>

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -12,12 +12,13 @@
 
 {% block maincontent %}
 {% if data %}
-<div id="histogram-show" style="height: 700px;">
+<div id="histogram-show" style="height: 80vh;">
     <script>
         var trace = {
             x: {{ bins }},
             y: {{ data }},
-            type: 'bar'
+            type: 'bar',
+            marker: {color: '#0033A0'}
         };
         var data = [trace];
 
@@ -35,7 +36,7 @@
     </script>
 </div>
 {% elif data2d %}
-<div id="histogram-show" style="height: 700px;">
+<div id="histogram-show" style="height: 80vh;">
     <script>
         var data = [
             {

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -62,8 +62,8 @@
 </div>
 {% else %}
 <div class="alert alert-danger">
-    <h2>No histogram found.</h2>
-    Check the spelling of the above URL and try again. Based on the URL, here are the queries you have requested:
+    <h2>No histogram found</h2>
+    Check the spelling of your query and try again. Here are the queries you have requested:
     <ol>
         <li>Run: <code>{{runnr}}</code></li>
         {% if lumisection %}<li>Lumisection: <code>{{lumisection}}</code></li>{% endif %}
@@ -74,10 +74,34 @@
 {% endblock %}
 
 {% block sidebar %}
-<h2>More from OMS</h2>
-<a class="nav-link" href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{runnr}}">Run {{runnr}}</a>
-<a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{runnr}}">L1 rates from run {{runnr}}</a>
-<a class="nav-link" href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{runnr}}">HLT rates from run {{runnr}}</a>
+<h3>More from OMS</h3>
+<ul>
+    <li><a href="https://cmsoms.cern.ch/cms/runs/report?cms_run={{runnr}}">Run {{runnr}}</a></li>
+    <li><a href="https://cmsoms.cern.ch/cms/triggers/l1_rates?cms_run={{runnr}}">L1 rates from run {{runnr}}</a></li>
+    <li><a href="https://cmsoms.cern.ch/cms/triggers/hlt_trigger_rates?cms_run={{runnr}}">HLT rates from run {{runnr}}</a></li>
+</ul>
+<hr>
+
+<h3>Jump again</h3>
+<form action="" method="GET" class="row">
+    <div class="col-6">
+        <label for="{{ form.runnr.id_for_label }}">Run</label>
+        {{ form.runnr }}
+    </div>
+    <div class="col-6">
+        <label for="{{ form.lumisection.id_for_label }}">Lumisection</label>
+        {{ form.lumisection }}
+    </div>
+    <div class="col-12">
+        <label for="{{ form.title.id_for_label }}">Title</label>
+        {{ form.title }}
+    </div>
+    <div class="col-12">
+        <div class="d-grid" style="margin-top: 5pt">
+            <button class="btn btn-primary" type="submit">Go</button>
+        </div>
+    </div>
+</form>
 
 {% endblock %}
 

--- a/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
+++ b/visualize_histogram/templates/visualize_histogram/visualize_histogram.html
@@ -1,0 +1,49 @@
+{% extends 'base_with_sidebar.html' %}
+{% load static %}
+
+{% block extra_head %}
+<!-- <script src="https://unpkg.com/vue@3"></script> -->
+<!-- <script src="https://unpkg.com/axios/dist/axios.min.js"></script> -->
+{% endblock %}
+
+{% block title %}
+Visualize histograms
+{% endblock %}
+
+{% block maincontent %}
+<div id="hist-id-12345" style="height: auto">
+    <script>
+        var x = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 3.0, 1.0, 9.0, 26.0, 68.0, 87.0, 161.0, 303.0, 589.0, 1056.0, 1702.0, 2509.0, 3273.0, 3827.0, 4188.0, 4116.0, 3921.0, 3547.0, 3150.0, 2639.0, 2426.0, 1975.0, 1671.0, 1496.0, 1261.0, 1160.0, 979.0, 816.0, 763.0, 719.0, 658.0, 607.0, 527.0, 501.0, 449.0, 433.0, 369.0, 370.0, 338.0, 319.0, 316.0, 266.0, 239.0, 226.0, 233.0, 233.0, 200.0, 175.0, 182.0, 160.0, 137.0, 157.0, 128.0, 134.0, 96.0, 99.0, 106.0, 97.0, 86.0, 84.0, 91.0, 72.0, 67.0, 63.0, 65.0, 70.0, 70.0, 54.0, 60.0, 65.0, 47.0, 60.0, 38.0, 55.0, 35.0, 52.0, 38.0, 39.0, 26.0, 37.0, 30.0, 23.0, 21.0, 30.0, 16.0, 18.0, 15.0, 26.0, 17.0, 15.0, 14.0, 710.0];
+        var trace = {
+            y: x,
+            type: 'bar'
+        };
+        var data = [trace];
+
+        Plotly.newPlot('hist-id-12345', data, 
+        {
+            bargap: 0, 
+            paper_bgcolor: 'rgba(0,0,0,0)',
+            plot_bgcolor: 'rgba(0,0,0,0)',
+            title: {
+                text:'Run 297178',
+                xref: 'paper',
+                x: 0,
+                font: {
+                    size: 40
+                }
+            }
+        }, {responsive: true});
+    </script>
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<h2>More from OMS</h2>
+This is a dummy content showing a rough design of the visualization page. 
+
+{% endblock %}
+
+{% block scripts %}
+
+{% endblock %}

--- a/visualize_histogram/tests.py
+++ b/visualize_histogram/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/visualize_histogram/urls.py
+++ b/visualize_histogram/urls.py
@@ -5,5 +5,6 @@ from . import views
 app_name = "visualize_histogram"
 
 urlpatterns = [
-    path("", views.visualize_histogram, name="visualize")
+    path("", views.visualize_histogram_dummy, name="visualize_histogram_dummy"),
+    path("<int:runnr>/<int:lumisection>/<title>", views.visualize_histogram, name="visualize_histogram"),
 ]

--- a/visualize_histogram/urls.py
+++ b/visualize_histogram/urls.py
@@ -1,10 +1,13 @@
 from django.urls import include, path
 
 from . import views
+import data_taking_objects.views
 
 app_name = "visualize_histogram"
 
 urlpatterns = [
-    path("", views.visualize_histogram_dummy, name="visualize_histogram_dummy"),
-    path("<int:runnr>/<int:lumisection>/<title>", views.visualize_histogram, name="visualize_histogram"),
+    path("", data_taking_objects.views.runs_view, name="visualize_histogram_dummy"),
+    path("<int:runnr>/", views.redirect_run, name="redirect_run"),
+    path("<int:runnr>/<int:lumisection>/", views.redirect_lumisection, name="redirect_lumisection"),
+    path("<int:runnr>/<int:lumisection>/<title>/", views.visualize_histogram, name="visualize_histogram"),
 ]

--- a/visualize_histogram/urls.py
+++ b/visualize_histogram/urls.py
@@ -1,0 +1,9 @@
+from django.urls import include, path
+
+from . import views
+
+app_name = "visualize_histogram"
+
+urlpatterns = [
+    path("", views.visualize_histogram, name="visualize")
+]

--- a/visualize_histogram/views.py
+++ b/visualize_histogram/views.py
@@ -71,10 +71,10 @@ def visualize_histogram_dummy(request):
 
     # Convert all available choices to a dict so that JS can understand it
     dummy_hist = LumisectionHistogram1D.objects.latest("lumisection_id")
-    #return redirect("visualize_histogram", runnr=dummy_hist.lumisection.run_id, 
-    #    lumisection=dummy_hist.lumisection.ls_number, 
-    #    title=dummy_hist.title
-    #)
+    return redirect("visualize_histogram:visualize_histogram", runnr=dummy_hist.lumisection.run_id, 
+        lumisection=dummy_hist.lumisection.ls_number, 
+        title=dummy_hist.title
+    )
     return visualize_histogram(request, runnr=dummy_hist.lumisection.run_id, 
         lumisection=dummy_hist.lumisection.ls_number, 
         title=dummy_hist.title)

--- a/visualize_histogram/views.py
+++ b/visualize_histogram/views.py
@@ -58,6 +58,7 @@ def visualize_histogram(request, runnr, lumisection, title):
                 "visualize_histogram/visualize_histogram.html",
                 {
                     "data": histobj.data,
+                    "is2d": False,
                     "bins": np.linspace(histobj.x_min, histobj.x_max, histobj.x_bin+1).tolist(), 
                     "title": histobj.title,
                     "runnr": target_lumi.run_id,
@@ -71,7 +72,8 @@ def visualize_histogram(request, runnr, lumisection, title):
                 request,
                 "visualize_histogram/visualize_histogram.html",
                 {
-                    "data2d": histobj.data,
+                    "data": histobj.data,
+                    "is2d": True,
                     "xbins": np.linspace(histobj.x_min, histobj.x_max, histobj.x_bin+1).tolist(), 
                     "ybins": np.linspace(histobj.y_min, histobj.y_max, histobj.y_bin+1).tolist(), 
                     "title": histobj.title,

--- a/visualize_histogram/views.py
+++ b/visualize_histogram/views.py
@@ -75,6 +75,3 @@ def visualize_histogram_dummy(request):
         lumisection=dummy_hist.lumisection.ls_number, 
         title=dummy_hist.title
     )
-    return visualize_histogram(request, runnr=dummy_hist.lumisection.run_id, 
-        lumisection=dummy_hist.lumisection.ls_number, 
-        title=dummy_hist.title)

--- a/visualize_histogram/views.py
+++ b/visualize_histogram/views.py
@@ -1,18 +1,80 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
+from data_taking_objects.models import Lumisection
+
+from histograms.models import LumisectionHistogram1D, LumisectionHistogram2D
+import numpy as np
 
 # Create your views here.
+
 @login_required
-def visualize_histogram(request):
+def visualize_histogram(request, runnr, lumisection, title):
     """
     View for histogram file manager. Lists all available datafiles and their
     parsing status
     """
 
     # Convert all available choices to a dict so that JS can understand it
+    try:
+        target_lumi = Lumisection.objects.get(run_id = runnr, ls_number = lumisection)
+        lumi1d_searchresults = LumisectionHistogram1D.objects.filter(title=title, lumisection=target_lumi)
+        lumi2d_searchresults = LumisectionHistogram2D.objects.filter(title=title, lumisection=target_lumi)
+        if len(lumi1d_searchresults) == 1: 
+            histobj = lumi1d_searchresults[0]
+            return render(
+                request,
+                "visualize_histogram/visualize_histogram.html",
+                {
+                    "data": histobj.data,
+                    "bins": np.linspace(histobj.x_min, histobj.x_max, histobj.x_bin+1).tolist(), 
+                    "title": histobj.title,
+                    "runnr": target_lumi.run_id,
+                    "lumisection": target_lumi.ls_number
+                }
+            )
+        elif len(lumi2d_searchresults) == 1: 
+            histobj = lumi2d_searchresults[0]
+            return render(
+                request,
+                "visualize_histogram/visualize_histogram.html",
+                {
+                    "data2d": histobj.data,
+                    "xbins": np.linspace(histobj.x_min, histobj.x_max, histobj.x_bin+1).tolist(), 
+                    "ybins": np.linspace(histobj.y_min, histobj.y_max, histobj.y_bin+1).tolist(), 
+                    "title": histobj.title,
+                    "runnr": target_lumi.run_id,
+                    "lumisection": target_lumi.ls_number
+                }
+            )
+        else: 
+            histobj = None
+            return render(
+                request,
+                "visualize_histogram/visualize_histogram.html",
+                {"data": None, "runnr": runnr, "lumisection": lumisection, "title": title}
+            )
+    except (Lumisection.DoesNotExist):
+        # Return with no context
+        render(
+            request,
+            "visualize_histogram/visualize_histogram.html",
+            {"data": None}
+        )
+    
+@login_required
+def visualize_histogram_dummy(request):
+    """
+    View for histogram file manager. Lists all available datafiles and their
+    parsing status
+    """
 
-    return render(
-        request,
-        "visualize_histogram/visualize_histogram.html"
-    )
+    # Convert all available choices to a dict so that JS can understand it
+    dummy_hist = LumisectionHistogram1D.objects.latest("lumisection_id")
+    #return redirect("visualize_histogram", runnr=dummy_hist.lumisection.run_id, 
+    #    lumisection=dummy_hist.lumisection.ls_number, 
+    #    title=dummy_hist.title
+    #)
+    return visualize_histogram(request, runnr=dummy_hist.lumisection.run_id, 
+        lumisection=dummy_hist.lumisection.ls_number, 
+        title=dummy_hist.title)

--- a/visualize_histogram/views.py
+++ b/visualize_histogram/views.py
@@ -6,6 +6,8 @@ from data_taking_objects.models import Lumisection
 from histograms.models import LumisectionHistogram1D, LumisectionHistogram2D
 from .forms import QuickJumpForm
 
+import data_taking_objects.views
+
 import numpy as np
 
 # Create your views here.
@@ -121,3 +123,21 @@ def visualize_histogram_dummy(request):
     # )
     print(request.GET)
     return render(request, "visualize_histogram/visualize_firstpage.html", {"form": form})
+
+@login_required
+def redirect_lumisection(request, runnr, lumisection):
+    """
+    View for histogram file manager. Lists all available datafiles and their
+    parsing status
+    """
+
+    return data_taking_objects.views.lumisection_view(request, runnr, lumisection)
+
+@login_required
+def redirect_run(request, runnr):
+    """
+    View for histogram file manager. Lists all available datafiles and their
+    parsing status
+    """
+
+    return data_taking_objects.views.run_view(request, runnr)

--- a/visualize_histogram/views.py
+++ b/visualize_histogram/views.py
@@ -1,0 +1,18 @@
+from django.shortcuts import render
+from django.http import HttpResponse
+from django.contrib.auth.decorators import login_required
+
+# Create your views here.
+@login_required
+def visualize_histogram(request):
+    """
+    View for histogram file manager. Lists all available datafiles and their
+    parsing status
+    """
+
+    # Convert all available choices to a dict so that JS can understand it
+
+    return render(
+        request,
+        "visualize_histogram/visualize_histogram.html"
+    )


### PR DESCRIPTION
Hi,

For this pull request I have restructured the frontend, basically reorganising pages to better help users navigate through MLPlayground. To reiterate from what I have explained:

- **Manage** is where we manage things, like import histograms from files, get list of all histograms from the DB, including 1D/2D LS histograms and run histograms. 
- **Discover** is where we discover things, including individual histograms with all accompanied data from OMS, CertHelper, etc., and a movie generator for all LS in the same run.
- **Challenge** is where we challenge people to submit models. The user views the task, submit either strategy for backend machines to train, and check for training reports.

For now, many links in these categories may not work since they are not implemented yet.

## Changelog
- Switched to Bootstrap 5.3 in case we want proper dark mode. Normally the plots should be drawn on white paper, but I want to implement automatic dark mode somewhere in case the user is using dark mode on browsers.
- Moved actions button to the first column in histogram file manager page.
- Moved filter forms in histogram file, 1D lumisection, and 2D lumisection manager pages.
- Fixed title histogram filter display into a proper format with checkboxes. The old implementation can be confusing to users.
- Added visualisation app. Now we can visualise histograms from 1D and 2D lumisection manager pages. Simply click on the plot and users will be directed to the new app.
- Minor UI tweaks.

## Known issues
- I wanted the navbar to be fixed, but still can't figure it out. _Maybe this is not really needed._
- ~/visualize/ URL should redirect to the latest 1D histogram (for now, I still have to figure out which histogram to serve). It is currently not redirecting, since I could not figure out a way to redirect without errors.~ 
  - ~Fixed in commit [868fa0c](https://github.com/CMSTrackerDPG/MLplayground/pull/90/commits/868fa0cff1b5a0f3362073af19edab6b6e5c8b0f)~ 
  - Now the main page /visualize/ should feature quick jump bar, allowing users to look into any histogram. Added in commit [3f09969](https://github.com/CMSTrackerDPG/MLplayground/pull/90/commits/3f099693119bee56cc283c609d83ab0b1f72b9f8)
- /visualize/ accepts the template of "<run_number>/<lumisection_number>/<title>" and "" (nothing) only. Other forms of URL will result in 404 error.

As always, please let me know if you have any suggestions.

Thanks,
Vichayanun